### PR TITLE
UI Probe for node instead of nginx

### DIFF
--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -89,7 +89,7 @@ spec:
               command:
                 - /bin/sh
                 - '-c'
-                - '[ -f /run/nginx.pid ] && ps -A | grep nginx'
+                - 'ps -A | grep node'
             initialDelaySeconds: 10
             timeoutSeconds: 1
             periodSeconds: 5


### PR DESCRIPTION
UI is not using Nginx anymore and the deployment will constantly kill the ui pod because the probe would fail.