### PR TITLE
RBAC: Allow ingresses manipulation on operator SA

### DIFF
--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -206,6 +206,12 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
           - apps
           resources:
           - deployments
@@ -236,7 +242,7 @@ spec:
         - apiGroups:
           - apps
           resourceNames:
-          - forklift-operator
+          - tackle-operator
           resources:
           - deployments/finalizers
           verbs:

--- a/tackle-k8s.yaml
+++ b/tackle-k8s.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: konveyor-tackle
 spec:
   displayName: Tackle Operator
-  publisher: Red Hat
+  publisher: Konveyor
   sourceType: grpc
   image: quay.io/konveyor/tackle2-operator-index:latest
 ---


### PR DESCRIPTION
This PR addresses RBAC issues when manipulating ingresses in k8s deployments