### PR TITLE
HUB: Set ADDON_WORKING_DIR on deployment

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -39,6 +39,7 @@ hub_bucket_volume_path: "/buckets"
 hub_bucket_volume_claim_name: "{{ hub_service_name }}-bucket-volume-claim"
 hub_seed_configmap_name: "{{ hub_service_name }}-seed"
 hub_seed_configmap_path: "/seed"
+hub_addon_working_path: "/working"
 hub_tls_enabled: false
 hub_tls_secret_name: "{{ hub_service_name }}-serving-cert"
 hub_log_level: 3

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -57,6 +57,8 @@ spec:
 {% endif %}
             - name: ADDON_SECRET_PATH
               value: "/var/run/secrets/tackle-addon"
+            - name: ADDON_WORKING_DIR
+              value: "{{ hub_addon_working_path }}"
             - name: DB_PATH
               value: "{{ hub_database_volume_path }}/{{ hub_database_filename }}"
             - name: DB_SEED_PATH


### PR DESCRIPTION
- Fixes #11
- Add ADDON_WORKING_DIR , defaults to /working
- Operator only adds the ENV variable, Hub will have to handle mounting/creating the directory