### PR TITLE
Add JAVA_OPTS to sso deployment

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -116,6 +116,7 @@ keycloak_sso_tls_enabled: false
 keycloak_sso_tls_secret_name: "{{ keycloak_sso_service_name }}-serving-cert"
 keycloak_sso_admin_username: "admin"
 keycloak_sso_admin_username_b64: "{{ keycloak_sso_admin_username | b64encode }}"
+keycloak_sso_java_opts: "-Dcom.redhat.fips=false"
 
 ui_image_fqin: "{{ lookup('env', 'TACKLE_UI_IMAGE') }}"
 ui_component_name: "ui"

--- a/roles/tackle/templates/deployment-keycloak-sso.yml.j2
+++ b/roles/tackle/templates/deployment-keycloak-sso.yml.j2
@@ -55,6 +55,8 @@ spec:
                 secretKeyRef:
                   name: {{ keycloak_sso_secret_name }}
                   key: admin-password
+            - name: JAVA_OPTS
+              value: {{ keycloak_sso_java_opts }}
             - name: PROXY_ADDRESS_FORWARDING
               value: 'true'
             - name: KEYCLOAK_IMPORT


### PR DESCRIPTION
- Add JAVA_OPTS to keycloak SSO deployment , operator variable keycloak_sso_java_opts
- Default keycloak_sso_java_opts to "-Dcom.redhat.fips=false"
- Fixes #26 