### PR TITLE
Parametize keycloak init delay

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -112,6 +112,8 @@ keycloak_sso_container_limits_cpu: "1000m"
 keycloak_sso_container_limits_memory: "1Gi"
 keycloak_sso_container_requests_cpu: "100m"
 keycloak_sso_container_requests_memory: "350Mi"
+keycloak_sso_liveness_init_delay: "60"
+keycloak_sso_readiness_init_delay: "60"
 keycloak_sso_tls_enabled: false
 keycloak_sso_tls_secret_name: "{{ keycloak_sso_service_name }}-serving-cert"
 keycloak_sso_admin_username: "admin"

--- a/roles/tackle/templates/deployment-keycloak-sso.yml.j2
+++ b/roles/tackle/templates/deployment-keycloak-sso.yml.j2
@@ -99,7 +99,7 @@ spec:
               path: /auth/realms/{{ app_name }}
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 60
+            initialDelaySeconds: {{ keycloak_sso_liveness_init_delay }}
             timeoutSeconds: 1
             periodSeconds: 10
             successThreshold: 1
@@ -109,7 +109,7 @@ spec:
               path: /auth/realms/{{ app_name }}
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 60
+            initialDelaySeconds: {{ keycloak_sso_readiness_init_delay }}
             timeoutSeconds: 1
             periodSeconds: 10
             successThreshold: 1


### PR DESCRIPTION
Allow a user to manipulate init delay (in seconds) via operator for the keycloak deployment, liveness or readiness via these Tackle CR spec vars:

keycloak_sso_liveness_init_delay: "xx"
keycloak_sso_readiness_init_delay: "xx"

This should help in cases where system performance is a considerable factor during keycloak start up. 
