### PR TITLE
Hub: Add support for reaper settings

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -42,6 +42,7 @@ hub_bucket_volume_claim_name: "{{ hub_service_name }}-bucket-volume-claim"
 hub_seed_configmap_name: "{{ hub_service_name }}-seed"
 hub_seed_configmap_path: "/seed"
 hub_addon_working_path: "/working"
+hub_task_sa: "tackle-hub"
 hub_tls_enabled: false
 hub_tls_secret_name: "{{ hub_service_name }}-serving-cert"
 hub_log_level: 3

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -90,6 +90,24 @@ spec:
                 secretKeyRef:
                   name: "{{ hub_secret_name }}"
                   key: keycloak_client_secret
+            - name: TASK_SA
+              value: "{{ hub_task_sa }}"
+{% if hub_task_reap_created is defined %}
+            - name: TASK_REAP_CREATED
+              value: "{{ hub_task_reap_created }}"
+{% endif %}
+{% if hub_task_reap_succeeded is defined %}
+            - name: TASK_REAP_SUCCEEDED
+              value: "{{ hub_task_reap_succeeded }}"
+{% endif %}
+{% if hub_task_reap_failed is defined %}
+            - name: TASK_REAP_FAILED
+              value: "{{ hub_task_reap_failed }}"
+{% endif %}
+{% if hub_task_retries is defined %}
+            - name: TASK_RETRIES
+              value: "{{ hub_task_retries }}"
+{% endif %}
           ports:
 {% if hub_tls_enabled|bool %}
             - containerPort: 8443


### PR DESCRIPTION
- Fixes #47
- Only hub_task_sa task is defined and set by default to tackle-hub
- hub_task_reap_created, hub_task_reap_succeeded, hub_task_reap_failed
  and hub_task_retries only apply when they are defined on the CR