### PR TITLE
Keycloak: Use init container image instead of busybox

### DIFF
--- a/roles/tackle/templates/deployment-keycloak-sso.yml.j2
+++ b/roles/tackle/templates/deployment-keycloak-sso.yml.j2
@@ -29,14 +29,8 @@ spec:
         app.kubernetes.io/part-of: {{ app_name }}
     spec:
       initContainers:
-        - name: keycloak-sso-theme
-          image: quay.io/quay/busybox
-          command:
-            - wget
-            - '-P'
-            - /deployments
-            - https://raw.githubusercontent.com/konveyor/tackle-keycloak-theme/main/tackle-keycloak-theme-0.1-SNAPSHOT.jar
-          resources: {}
+        - name: keycloak-theme
+          image: quay.io/konveyor/tackle-keycloak-init:1.2.0
           volumeMounts:
             - name: {{ keycloak_sso_service_name }}-theme
               mountPath: /deployments


### PR DESCRIPTION
Currently we use a busybox image which calls wget to obtain theme .jar file and inject it into a volume for keycloak use , this new image based approach does the same but has the advantage in proxy configurations where sites might not allow to download files directly , only images.
