### PR TITLE
Specify Keycloak User password format

### DIFF
--- a/roles/tackle/templates/configmap-keycloak-sso.yml.j2
+++ b/roles/tackle/templates/configmap-keycloak-sso.yml.j2
@@ -467,6 +467,7 @@ data:
       "requiredCredentials": [
         "password"
       ],
+      "passwordPolicy": "length(8) and upperCase(1) and lowerCase(1) and digits(1)",
       "otpPolicyType": "totp",
       "otpPolicyAlgorithm": "HmacSHA1",
       "otpPolicyInitialCounter": 0,


### PR DESCRIPTION
Adding password format requirement to the Keycloak initial Tackle realm configuration.

Proposal to a valid password format is to:
- have minimal length 8 chars
- contain at least 1 uppercase letter
- contain at least 1 lowercase letter
- contain at least 1 digit

**The password format could be discussed in reviews.**

More possible options are in Keycloak docs:https://github.com/keycloak/keycloak-documentation/blob/main/server_admin/topics/authentication/password-policies.adoc

https://issues.redhat.com/browse/TACKLE-522