### PR TITLE
Wait for PG deployments to be in running state

### DIFF
--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -64,6 +64,19 @@
           state: present
           definition: "{{ lookup('template', 'deployment-keycloak-postgresql.yml.j2') }}"
 
+      - name: "Check status of Keycloak PostgreSQL Deployment"
+        k8s_info:
+          api_version: v1
+          kind: Pod
+          namespace: "{{ app_namespace }}"
+          label_selectors:
+             - app.kubernetes.io/name = {{ keycloak_database_service_name }}
+        register: pod
+        until: pod.resources[0].status.phase == "Running"
+        retries: 4
+        delay: 10
+        ignore_errors: true
+
       - name: "Check if Keycloak SSO Secret exists already so we don't update it"
         k8s_info:
           api_version: v1
@@ -203,6 +216,19 @@
     k8s:
       state: present
       definition: "{{ lookup('template', 'deployment-pathfinder-postgresql.yml.j2') }}"
+
+  - name: "Check status of PathFinder PostgreSQL Deployment"
+    k8s_info:
+      api_version: v1
+      kind: Pod
+      namespace: "{{ app_namespace }}"
+      label_selectors:
+        - app.kubernetes.io/name = {{ pathfinder_database_service_name }}
+    register: pod
+    until: pod.resources[0].status.phase == "Running"
+    retries: 4
+    delay: 10
+    ignore_errors: true
 
   - name: "Setup PathFinder Service"
     k8s:

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -73,8 +73,8 @@
              - app.kubernetes.io/name = {{ keycloak_database_service_name }}
         register: pod
         until: pod.resources[0].status.phase == "Running"
-        retries: 4
-        delay: 10
+        retries: 20
+        delay: 2
         ignore_errors: true
 
       - name: "Check if Keycloak SSO Secret exists already so we don't update it"
@@ -226,8 +226,8 @@
         - app.kubernetes.io/name = {{ pathfinder_database_service_name }}
     register: pod
     until: pod.resources[0].status.phase == "Running"
-    retries: 4
-    delay: 10
+    retries: 20
+    delay: 2
     ignore_errors: true
 
   - name: "Setup PathFinder Service"


### PR DESCRIPTION
- Allow PG pods to be in running state before continuing deployment of
  keycloak and pathfinder
- Fixes race issues when PG is not yet forwarding traffic while other
  applications are trying to access during start-up