### PR TITLE
Enhance tackle_cleanup script

### DIFF
--- a/tools/tackle_cleanup.sh
+++ b/tools/tackle_cleanup.sh
@@ -1,10 +1,56 @@
 #!/bin/bash
-# Cleanup Tackle
+# Cleanup Tackle in kubernetes and ocp, a valid user session to cluster is required.
 
 OC_BINARY=`which oc`
+KUBE_BINARY=`which kubectl`
 NAMESPACE="konveyor-tackle"
 CATSOURCE="konveyor-tackle"
+CRDS="tackles.tackle.konveyor.io addons.tackle.konveyor.io"
 
-${OC_BINARY} -n openshift-marketplace delete catalogsource ${CATSOURCE}
-${OC_BINARY} delete project ${NAMESPACE}
-${OC_BINARY} delete crd tackles.tackle.konveyor.io addons.tackle.konveyor.io
+function usage () {
+echo "Valid options for $(basename $0): "
+echo -e "\t-o : OpenShift cleanup"
+echo -e "\t-k : Kubernetes cleanup"
+echo -e "\t-h : Print help"
+}
+
+if [ $# -eq 0 ]; then
+  usage
+  exit 1
+fi
+
+while getopts 'okh' opt; do
+  case "$opt" in
+
+    o)
+      TYPE=openshift
+      ;;
+
+    k)
+      TYPE=kubernetes
+      ;;
+
+    h)
+      usage
+      exit 0
+      ;;
+
+    ?)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ ${TYPE} == "openshift" ]; then
+
+  ${OC_BINARY} -n openshift-marketplace delete catalogsource ${CATSOURCE}
+  ${OC_BINARY} delete project ${NAMESPACE}
+  ${OC_BINARY} delete crd ${CRDS}
+
+elif [ ${TYPE} == "kubernetes" ]; then
+
+  ${KUBE_BINARY} -n ${NAMESPACE} delete catalogsource ${CATSOURCE}
+  ${KUBE_BINARY} delete namespace ${NAMESPACE}
+  ${KUBE_BINARY} delete crd ${CRDS}
+fi


### PR DESCRIPTION
- Allow handling of kubernetes/minikube cluster cleanups

Usage:
```
./tackle_cleanup.sh -h
Valid options for tackle_cleanup.sh: 
	-o : OpenShift cleanup
	-k : Kubernetes cleanup
	-h : Print help
```