### PR TITLE
Add operator release automation tools

### DIFF
--- a/tools/cut-release.py
+++ b/tools/cut-release.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import jinja2
+
+# Files to template, the template name to be used and target file path relative to --project-path
+files = { 1: {'template': 'clusterserviceversion.yaml.j2', 'path': 'bundle/manifests/tackle-operator.clusterserviceversion.yaml'},
+          2: {'template': 'annotations.yaml.j2', 'path': 'bundle/metadata/annotations.yaml'},
+          3: {'template': 'bundle.Dockerfile.j2', 'path': 'bundle.Dockerfile'},
+          4: {'template': 'tackle-k8s.yaml.j2', 'path': 'tackle-k8s.yaml'}}
+
+parser = argparse.ArgumentParser(
+    description='Prepare a new Tackle project release',
+    epilog='This script is used to prepare a new release branch for Tackle, please review changes before submitting PR.')
+
+parser.add_argument('--version', dest='version', required=True, type=str, help='version must follow semver format (i.e 2.0.0) unless latest')
+parser.add_argument('--release_prefix', dest='release_prefix', default='v', type=str, help='release_prefix is the scheme used for branching project (i.e release-v), default is v')
+parser.add_argument('--channel', dest='channel', type=str, help='OLM channel must follow semver format (i.e release-v2.0), if not supplied will be derived to X.Y from version')
+parser.add_argument('--templates-path', dest='templates_path', type=str, help='Absolute path to directory containing jinja2 templates, default is templates')
+parser.add_argument('--project-path', dest='project_path', type=str, help='Absolute path to directory containing project root, where rendered templates will output, default is CWD')
+
+args = parser.parse_args()
+
+# Define templating func
+def template(rendered_file_name, template_file_name):
+    rendered_file_path = os.path.join(args.project_path, rendered_file_name)
+
+    environment = jinja2.Environment(loader=jinja2.FileSystemLoader(args.templates_path),
+                                     keep_trailing_newline=True)
+    output_text = environment.get_template(template_file_name).render(render_vars)
+
+    with open(rendered_file_path, "w") as output_file:
+        output_file.write(output_text)
+    return
+
+# Init script path
+script_path = os.path.dirname(os.path.abspath(__file__))
+
+# Set project_path defaults if not supplied
+if not args.project_path:
+    for f_id, f_info in files.items():
+        f_dirname = os.path.dirname(f_info['path'])
+        d = os.path.join(script_path, f_dirname)
+        if not os.path.exists(d):
+            os.makedirs(d)
+    args.project_path = script_path
+
+# Set templates defaults if not supplied
+if not args.templates_path:
+    args.templates_path = os.path.join(script_path, "templates")
+
+# Set channel defaults if not supplied
+if not args.channel:
+   short_version = args.version.rsplit(".",1)[0]
+   args.channel = args.release_prefix + short_version
+
+# Init rendering vars
+render_vars = {}
+
+render_vars["version"] = args.version
+render_vars["release_prefix"] = args.release_prefix
+render_vars["channel"] = args.channel
+render_vars["namespace"] = "konveyor-tackle"
+
+# Walk all values and print before templating
+
+#for key, value in render_vars.items():
+#    print(key,":", value)
+
+# Template
+
+for f_id, f_info in files.items():
+    template(f_info['path'],f_info['template'])

--- a/tools/templates/annotations.yaml.j2
+++ b/tools/templates/annotations.yaml.j2
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: tackle-operator
+  operators.operatorframework.io.bundle.channels.v1: {{ channel }}
+  operators.operatorframework.io.bundle.channel.default.v1: {{ channel }}
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: ansible.sdk.operatorframework.io/v1
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/tools/templates/bundle.Dockerfile.j2
+++ b/tools/templates/bundle.Dockerfile.j2
@@ -1,0 +1,21 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=tackle-operator
+LABEL operators.operatorframework.io.bundle.channels.v1={{ channel }}
+LABEL operators.operatorframework.io.bundle.channel.default.v1={{ channel }}
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.15.0+git
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=ansible.sdk.operatorframework.io/v1
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/

--- a/tools/templates/clusterserviceversion.yaml.j2
+++ b/tools/templates/clusterserviceversion.yaml.j2
@@ -1,0 +1,302 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: tackle-operator.{{ release_prefix}}{{ version }}
+  namespace: konveyor-tackle
+  annotations:
+    capabilities: Seamless Upgrades
+    description: >-
+      Tackle contains tools that support the modernization and migration of applications to OpenShift and Kubernetes
+    categories: 'Modernization & Migration'
+    certified: "false"
+    support: Red Hat
+    repository: https://github.com/konveyor/tackle2-operator
+    containerImage: quay.io/konveyor/tackle2-operator:latest
+    olm.skipRange: '>=0.0.0 <{{ version }}'
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "tackle.io/v1alpha1",
+        "kind": "Tackle",
+        "metadata": {
+          "name": "tackle",
+          "namespace": "konveyor-tackle"
+        },
+        "spec": {}
+      }
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "tackle.konveyor.io/v1alpha1",
+          "kind": "Tackle",
+          "metadata": {
+            "name": "tackle",
+            "namespace": "konveyor-tackle"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "tackle.konveyor.io/v1alpha1",
+          "kind": "Addon",
+          "metadata": {
+            "name": "move2kube-plan",
+            "namespace": "konveyor-tackle"
+          },
+          "spec": {
+            "image": "quay.io/konveyor/tackle-addon-move2kube-plan:latest"
+          }
+        }
+      ]
+    certified: "false"
+    support: https://github.com/konveyor/tackle2-operator/issues
+    operatorframework.io/suggested-namespace: konveyor-tackle
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - name: tackles.tackle.konveyor.io
+      version: v1alpha1
+      kind: Tackle
+      displayName: Tackle
+      description: Tackle
+    - name: addons.tackle.konveyor.io
+      version: v1alpha1
+      kind: Addon
+      displayName: Addon
+      description: Tackle Addon
+  description: |+
+    The Tackle Operator fully manages the deployment and life cycle of Tackle on Openshift and Kubernetes.
+
+    ### Install
+    Once you have successfully installed the Operator, proceed to deploy components by creating the required Tackle CR.
+
+    By default, the Operator installs the following components on a target cluster:
+
+    * Hub, to manage the application inventory and coordinate the migration process.
+    * UI, the web console to manage the application inventory and drive the migration waves.
+    * Pathfinder, a service to manage the assessment questionnaires.
+    * Keycloak, to manage authentication, including with 3rd-party providers.
+
+    ### Documentation
+    Documentation can be found on our [website](https://tackle-docs.konveyor.io).
+
+    ### Getting help
+    If you encounter any issues while using Tackle operator, you can create an issue on our [Github repo](https://github.com/konveyor/tackle2-operator/issues), for bugs, enhancements or other requests.
+
+    ### Contributing
+    You can contribute by:
+
+    * Raising any issues you find using Tackle Operator
+    * Fixing issues by opening [Pull Requests](https://github.com/konveyor/tackle2-operator/pulls)
+    * Improving [documentation](https://github.com/konveyor/tackle-documentation)
+
+  displayName: Tackle Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAANUAAADVCAYAAADAQLWDAAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9TpSJVB4uIOGSoThZERRy1CkWoEGqFVh1MLv2CJg1Jiouj4Fpw8GOx6uDirKuDqyAIfoC4uTkpukiJ/0sKLWI8OO7Hu3uPu3eAUC8zzeoYBzTdNlOJuJjJroqhV4QRwgAi6JWZZcxJUhK+4+seAb7exXiW/7k/R4+asxgQEIlnmWHaxBvE05u2wXmfOMKKskp8Tjxm0gWJH7muePzGueCywDMjZjo1TxwhFgttrLQxK5oa8RRxVNV0yhcyHquctzhr5Spr3pO/MJzTV5a5TnMYCSxiCRJEKKiihDJsxGjVSbGQov24j3/I9UvkUshVAiPHAirQILt+8D/43a2Vn5zwksJxoPPFcT5GgNAu0Kg5zvex4zROgOAzcKW3/JU6MPNJeq2lRY+Avm3g4rqlKXvA5Q4w+GTIpuxKQZpCPg+8n9E3ZYH+W6B7zeutuY/TByBNXSVvgINDYLRA2es+7+5q7+3fM83+fgAoT3KJHi4ioAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAN1wAADdcBQiibeAAAAAd0SU1FB+UMBxYVO0xvJdsAABaRSURBVHja7Z15WFTX3ce/M8CwrzLgALLIpqBsIlEUcUHEfW1s9pq3aUza1GjT2rQ1m0ltGm1q2zeabibpU43JG01UBDcwuAEqIiCrooAg+zLIzDAMM+8fEwfGYRsjIvL9PM88j3PvPfdezpmP53fOPecewaTItzUghNw3hMwCQigVIZSKEEpFCKFUhFAqQigVIYRSEUKpCKFUhBBKRQilIoRSEUKpCCGUihBKRQilIoRQKkIoFSGUihBCqQihVIRQKkIIpSKEUhFCqQihVIQQSkUIpSKEUhFCKBUhlIoQSkUIoVSEUCpCKBUhhFIRQqkIoVSEUCpCCKUihFKNeAQCQDKqY9DOL3bsgKmJhhlNqUYGEmclnllQi+nhLYN2jXHecqxdVY0Jfm0QCCjXg8aUWfBgsLXqxKzJLQjykUMg0OBqhcWgX29xTBPC/GU4lu6AmiYzFgJrqkeLoLEyBI+VPfCaY8zodjw2sZUFQKkIoVSEEEpFCKUihFIRQqkIIZSKEEpFCKUihFAqQigV6QuBABCJOExzuMCSesjw9nbG1Cm+CAsbAx8fMdzcHGBhoR0Mq1ZrUN9wG+VlDcgvqMKFCzdw4cJ1KJWdzDhKRbpjZmaC+fMnYtWqSASNd+s9rBAK4CK2hYvYFpGR3nj2mWhIpXIkJeXiv/9NR9WtZmYmpSJxcUF4dd1cjB5tf0/p7ewssXp1FFaujMTXX2fhox0pAKTMWEo18rCwssK2rasRGxt4fwrSVIhVqyIxe/Z4fPmf3QDOM5Mp1cjB1lGCNU+ug52D030/t5OTNX7y8x/jSsYoFGUlM7Mp1aOPg/MYTF+yHuYWNoN2DYFAgAlTVkBkbo3cc18x0x8w7FJ/gFjbiTFt0bpBFao7AeHzEBiRwIynVI9oSGBqiinzXoSFld0DvW7wY8vhGziOBUCpHj2WrEyAg9jzgV9XIBBg2RNPwc7OgoVAqR4d/PxcMCs+ZujCTltbvPzSbBYEpXp0ePHFmRAKhzarly2LgJubAwuDUg1/PD1HIXbG93sWpVB0IOtSGfbuzcSBA9n32KYT4qknp7BAHkT7mVkwuCxaFAqhUGBUmo6OTly4cAPnL1zHxYtlKCy8hc5OtW5/cUk1frEhAQLjTov58ydi+1+OcawgpRrexM0Zb9TxZWUNWPP8vyCVKno95vPPMyEUCrFhfbxR57azs0TkJB+cPXeVBcPwb3giFtvC03OUUWn2f53Vp1B32L07HTs/Pmn0PUVGerNgKNXwJSjIzeg0KScKBnzsP/+Zhr17M406//jxEhYMpRq+eBlZSxUXVxs9fWPbn47g3LlrA78nb2cWDKUavjg5WRt1/OnTJUZfQ63WID1j4FI5OVqzYCjV8MXSUmTU8enppfd0neAg9wEfa2oq5NR8SjV8aW8f+GqJSqUKObkVxhegUICoKB+jajaVil3qlGqY0twiH/CxDQ1tUKuNX7tq3DgJHBysBnx8S4v8nq5DKNVDQWPj7QEfK5HYY+2LM42+xkwjZw43NbWxYCjV8KWg4JZRxz//fAye+OFjRqWZNcu4h8tX8qtYMJRq+FJSUoO2tnaj0qxfH4/4+OABHRvg7wofH+O6yHNzKlgwlGr4olZrUFxcY3THw+Z3lmPOnKBej7G1tUBcXBBef32h0fd0/UY9C2aQYd/qIJOWVoTwcOMmJ5qYCPHeuytgLjLB4aRcuIhtMWGCB0JCPBAR4YVx4yRGD9IFAKlUgby8ShbKICOYFPk2u4IGEVdXOxw6+KrRI8oBQKMB5HIlrKxE9+VevvnmEja/e5CFwvBveFNTI0V+/r3VDgIB7ptQAHD8RD4LhFI9Ghw/PvQ/ZqlUgQsXbrAwKNWjwdFjV6AZ4iA7NbUAHR0cSUGpHqEQsKBgaJ8PMfSjVAwBGfpRKtK/VEMVAjL0o1SPJFW3mocsBGToR6kYAjL0o1Tk4Q0BT54sZOhHqRgCDvfakVKRR/ZHLpUqcP7CdWY6pWIIyNCPUhFjQ8DCqgcmMKFUDAHvE62tDP2GCs6nGgqpjuXjlZ/F9TsdRNXRjuqyHDTW3oBapYKV3Si4eYfCxsG132ukpjL0o1QjMAQMGt/7a6ErS7OQnbYbCplUb3veua/gFRiN0JgfwtTMnKEfwz8ykB99eVE60pM/NhAKADQaDW4UnsGZQ9uh7lQx9KNUpLtUPfUCytuacSntvwA0UGuA8hoRvs2yxxdHxTh4yhGdndqYsf7WVRRlJfUc+rHXj+HfiAwBq3oOAUuvfAtVh/YNTMczHHCxwKbbXnO0K02wYnY9hALgas4JBE6aD6HQlKEfayrS24+/vrL4uzBPgMLrlgb7S8otcCxdu3avsl0GaUOVYeh3nqEfpWIIqEMhawEAVDeYoU1h0mO6Ww0ig+MZ+lEq0i0E7ImaRrNe03mNbtfruGDoR6nIACSY6CuDl6Tnt9sGenUtfCDo9rCLoR+lIgBO9LIcqYmJBitmNUDirOzqphCpETxWBolzz0v0nPy2iKHfQwB7/4aYysomXLtWC19fF4N9FuZqPDGvHkVllnBxUsLFqQN9vZj22LErzFDWVAQAUlILe91nLlIjxL8No0f1LVRTkwyZmaXMTEpFAGDv3kzIZMrvdY7PPjsDlUrNzKRUBACam2X48MOj95y+oOAW9n6RyYxkm4p0Z//XWRjrK4aTkekaGmXY+MYXUCrZQcGaihiwbdsRNDfLjErz5+1HUV3dwsyjVKQ3pK0Ko45vMWKxbkKpRiStbSZGHS/QCJhplIr0hf6odEKpyPemqMwSKecdBny8BlwIk1KRfsnIszFKLEKpCMWiVGToxEq9aN/nMd5u7cwoSkWMIT3Htk+xHpvQiulhUmYUpSLGitVXKDg9rBWeo1ljUSpidCh4spcaSyDQIH5KMwQC9gRSqhGOhbkaDraqAR9/LscWWYXWPe4TO3bATdzBTKVUI5sn4uuxdmU1wgLbBpwmLcseanXPoyjG+XDIEqUa4djadEIgABKmNiM88PaA0sjbhaht6nlywSh7JTOVUo1s9qWMQvNtEwgEGsyb2oKwgIHVWJpexvvZWXGSIqUa4dysESH5jKOusyEhugmh/YhlYa6G2LHntpNKxcG1lIqgpduodIEAmN+PWHMmt8DUpOdePqmRI9zJ4MCZv0Mt1W1TdKiEMDNV64nlYNuJczk2UHZo/99zdlBhdlQTfN17fx5145Y5M5RSkc5OAUqrzBHoKdersaJDpIgKbkVjiymsLTthbanu9zwl5ZbMUIZ/BAAycmx77HwwNdHAxamjX6EAIKvQGq0yhn+UigAAKutEKLh+77VMo9QUp7PtmJGUinTn8BlHVNWJjE7XJhfi/447Q6FkUVIqokeHSoDdyc7Iu2Y98BquVoRdB1zR0MKm8cMES+OhEkuIg2mOyC62wtSJrfCStBt0n2s0AlQ3mOF8vg3ySy17fRBMKBXpRkW1OSqqzWFmqoZklArWViqYmgJtMiHqmszYIUGpyPepucprRABEzAy2qQihVIQQSkUIpSJkRDBiOyo8PBwRNdkH5RWNuHDhBtwkDpgyZSwU7SocOZKL1Y9HYdWqSHh4OKG6pgWHE3Pw712noFR2IizMEz7ezkg+kgu5vAO2thaYGxeEFqkCdXWt8PMVo7CwGvkF2pXnZ80cB0dHK1y4WIaw0DF699GuVKGxsQ1jPBxxJb8KRUXVEIlMsGhhKADgUGIOYmcE4LnnpsHPzxVSqRwpKQXY+fFJNDfLMG6cBEHjJQAAtUaDkpJaXLlSyV/2EGLi5jbrrZH4h095zBdvvbUMQhMhMjJKsWPHM1i6NBzHT+Tj6aei8dxz02BvbwWVSg0HeytERHghJGQMjhzJwzPPRGPt2pnwcHfCiZQCSCT2+Ntfn8ZYH2fk5VXi3c0r4Opqh6TkXJibm+LTT3+M6Gg/HPjmEv72t6cRGxuo+0yO9MapU8V4772V8B0rxoGD2Zg3byLeeGMJBAIBRjnb4Le/WQRnZ1t0dqphY2OOoCA3zJw1DklJuVgwfyLWr49HTEwAZswIxPJlEbCyEiE9g0uVsqYaIgQCYNOmJfD1dcGnn55Bc7MMCxeGoKlJho0bv8Sl7DL4+bni/fd/gMmTfbBkcZgubXx8MPLybuLM2au6badPl6CxsQ2RkT6wshIhcpI3zM1NkZSci7bvliBtbGzD1m3JAIAOZSdOny5Bbu5NhIV5IjBwNFY/PhkaDbBv/0X88f3HoVKpsWnTPpxIKYBYbIvNm5cjItwLP3khFi0t2vWsjh67gtOnS7DxV/Px1FNTsXtPBmpr+T5AtqmGgNgZgZgbF4TMzFL870cpiI0NBADs2nUKWZfKoNEAJSU12L79GABgxoxAvfTr1s3FpAgv3ffOTjWOHr0CkcgEUVFjMX26PwAgMTFHd4yFhRliYgIQExOATrV2xMTOj08CADb+aj6Cg92RerIALi52MDUV4tChyzh2PB9qtQY1NVK8u/mg9l5iA3TnrK9rRV5eJdra2iEQaK9BKNWQYGWlfbDq7u4ICwszWFtpJ/rV1bXqHXfnu7V110TA/PwqmJgI8dprCXrHHkq8DACIme6P6Gg/1NW16q0cb2kpwpzZ4zFn9nh4e48CAGRklCLrUhlCQsZArdbgH/9I091bXf1d91LfCo0GsOl2L08+OQX7vvopXFzscOlSOSoqGvjrplRDw40b9Th8OAfu7o7YsH4eioqrAQCLFoVCKOwaV7d0STgAoKioWrdt3/6L+OabSxCJ9KPowsJbuHq1FgkJEzF6tD2SknOhVneN4auqakL0tN8jetrv8dlnZ3Xbv/ziPAAgM7MUJSU1KC6uAQDMjQuCpWVXzbN4cRgEAqCw273kF1ShsrJJGwoezYOG79WkVENFfsEtbPlDIioqGrFsWTikUjnq6loxbZo/Pvnkf/DzV+Kwc8ezWLlyEmQyJfZ8nqGX/v0/JiEvz7C37VDiZZiba2U7fDhHb59E4oDkpA26j4mJthjkCu0LXWTftb0yM0uRl1cJb29n7Nm9FuvWzcUf3/8BfvnafKjVGuzadVp3zrS0Yrz73iEAwAsvxMLGhlPr2fv3gHEW22KsjxgF+VU4l34NV6/Wws/XBR7ujtjyh0RMmuQNP18XhIaOgZubAxoabmPjr79EUVE1/P1dYGtriXPnruHatVqcPXsVwcHuqKxqxokT+QCAyspmRE7yRm7uTez9rgYyNzdD9FRfNDfL0N7eoft8te8iNBoNnJxs4O/visKiW8jIKIVGA5w+U4KQEA/4+7siNGQMfHzEkMuV2LIlEaknC+Hp6QSx2A4XL95ASkoBnJ1tYGkpgkLRoVerkgfY+TUp8m0GCj1gZqbtaHB3d0B93W2cS78KuXxoXqssEADhYV7w83dBq1SBs+eucgFtSkUI21SEkHtkxD78lUjsER7uZXQ6haIDKSkFettCQ8dALLbVfa+ubumx86I3Avxd4TNWDHt7S7S1taOuthVX8qvQ1mb4jr/gYHdIJF1L6nSq1Eg9Wah3jIWFme752B00GiAtrQguLnYIvWuo1NmzV9HcLOvzHoOD3eHlNWrAf1NqasGQhcuUaoiYOMED77y9zOh0dXWtelKZmZlg29bVcHCw0pNqydK/6HWj341IZIJVKyPx5JNTMHq04bpT7e0qpKYWYsfOVF1XOQCsfnwyFiwI0X2XyzsQM2OLXvvrjU1LEB8frHe+HTtTceJEJyLCPfHmm0v19j3//L/7lWrxolCsWhU54Hxakl0OubyZ4R8xnunT/PWEAoDRo+0REeHVZy35ySc/xoYN83oUCgDMzU2RkDABe3a/iLlxQQO+n1d+Fmcg1MFDl/Gvf51iYVGq4cHChSG9bA/tcbuTkzX+8fcfIcDfdUDnt7ISYfPmFQgL8+y/dlgchmefjdbblpVVhi1bDrGgGP4NPvkFVfj9lkS9bTNiAgzaItu3H9MNhAUAhbzr3/b2loiO9u/x/HFzgvDBB0m6B7l3eOvNpQa1U0uLHImJl3GjrAEODlaYEROACRPcu7V5SnDzZmOff09EuBdef32h3rbr1+vx2i/3QqnsHJQ83PKHxF5HbvQXTlKqR5CbN5tw8+ZFvW0uYlsDqRIP56CxsedVOBISJkIk6nqzkVQqh52d9k2zlpZmmDlznN5oirAwT0RH++mdo7yiES+88AkaGroWfdu16xReeSUOy5ZGYOu2ZIMRGXfj7e2MrVtXw8zMRO9HveEXn0MqVQxaHu7fn9Vnu5FSEaNZdFeI95e/Hsfvfru4KwRcEKInRNwcw7bR9u3H9IQCtD11H32Ugt2701Ff3/cKiyYmQvz5wydgZ2fRVZsqOrDu1T2oqGgc1L9/8eIwaHqoqpKT86BUqigVMY6xPmKM/27GLQCUlzfgwIFsvPzSbDg5ad8yO3myD1xd7VBTo53XFBCo345SKDqQllbU4/lVKnW/QgHaXkQPD0e9bR9sTX4gs383/W5xj9u1c8pGrlTsqLjXWmqRfi11/EQB1GoNTp8p6cpcoQAJCRN1321sLPTS1NffHpTR5AsXhugG6RJKNTwyTShAQsIEvW0nU7UPYE+lFfcaIjbeFea5uNgNyo//zqxgwvBv2BAVNRYuLl1L16jVGixfEYFlmgi9eU8A4OPjjKAgN+TnVyH7cgWmTPHVC91iYwMNRmjc2ScSmeL27fZ+70elUqOmpgXu7l1h4Jo103Epuxzp6dcGr7ZevL3HNtVI7vljTXWfOiiEQgGWL4vAiuURmN8t3OveYQEAR4/kobNTfwG39a/Gw6XbECdAOyripy/Pwf59r+AHqyL7rM3Uag02/vpL/Hzdbr1hQUKhAO+8vUxv+NT9prZWipoaw89I7xFkTWUk1tbmmDkz0Kg0CQkT8eftx1Be0YgDB7OxfFmEbp9EYo89e9Zi3/6LuF5aB3t7K8yZM173sHfjxgV4/PEofPBBEjLPXzc4d3u7Ct9+q+3s2PanZL3eRycna7z33gq89NJ/DGTuzsyZ4+Af0PPD6OZmuW6O2N2sWDGpx5oK0L4e4ObNJkpF+icuLsjgpSq/27QPjY1dIY+npxN+vXGB7ru9vSWmTfPHyZOF+PDDo5g4wQN+fi56+9f8aHqv1/T2doatXf8rLX799SVERY1F/Nxgg/bVjp2pvaa7exRGd4pLanqVqvvfeDe/+c1XI1Yqhn/fM/QrK2tAcnIeMjNLdZ99+y4avDhmwQJtWCiTKfHSy5/h8uWKAV2vs1OND7Ym9frDvpstWxJx61aL3rY1a6Zj6lRfFh6levhwkzgYjME7fjy/x3bO3dMxYqYH6AbeNjXJ8JMXP8XWbcm9PouSyZRITs7DU0//HV98Nx1/ILS2KvDGm/v12jXa9tVyg7YbGRw487cb/v6u8O8WlgHa5093Rge4SRwQFOymt//y5QqDWulOWyk42F1vW3Z2uYFEQqEAE4Ld4e3tDEcnazQ1taG6WorLl8vR3m74AHUg86kAIDLS22D0/PXr9VAoOhAa4jHgPGmRKnDmTAmCgtzgbcR8qkvZ5QY1JqUihDD8I4RSEUKpCCGUihBKRQilIoRQKkIoFSGUihBKRQihVIRQKkIoFSGEUhFCqQihVIQQSkUIpSKEUhFCKBUhlIoQSkUIpSKEUCpCKBUhlIoQQqkIoVSEUCpCCKUihFIRQqkIIZSKEEpFCKUihFIRQigVIZSKEEpFCKFUhFAqQh4F/h83SxXt9IY9sQAAAABJRU5ErkJggg==
+    mediatype: "image/png"
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: tackle-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: tackle
+              name: tackle-operator
+          template:
+            metadata:
+              labels:
+                app: tackle
+                name: tackle-operator
+            spec:
+              serviceAccountName: tackle-operator
+              containers:
+              - args:
+                - --health-probe-bind-address=:6789
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                - --leader-election-id=tackle-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: TACKLE_HUB_IMAGE
+                  value: quay.io/konveyor/tackle2-hub:{{ release_prefix}}{{ version }}
+                - name: PATHFINDER_DATABASE_IMAGE
+                  value: quay.io/centos7/postgresql-12-centos7:latest
+                - name: PATHFINDER_IMAGE
+                  value: quay.io/konveyor/tackle-pathfinder:noauthentication
+                - name: KEYCLOAK_DATABASE_IMAGE
+                  value: quay.io/centos7/postgresql-12-centos7:latest
+                - name: KEYCLOAK_SSO_IMAGE
+                  value: quay.io/keycloak/keycloak:16.1.1
+                - name: TACKLE_UI_IMAGE
+                  value: quay.io/konveyor/tackle2-ui:{{ release_prefix }}{{ version }}
+                - name: ADDON_ADMIN_IMAGE
+                  value: quay.io/konveyor/tackle2-addon:{{ release_prefix }}{{ version }}
+                - name: ADDON_WINDUP_IMAGE
+                  value: quay.io/konveyor/tackle2-addon-windup:{{ release_prefix }}{{ version }}
+                name: tackle-operator
+                image: quay.io/konveyor/tackle2-operator:{{ release_prefix }}{{ version }}
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 6789
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 6789
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 768Mi
+                  requests:
+                    cpu: 10m
+                    memory: 256Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
+      permissions:
+      - serviceAccountName: tackle-operator
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resourceNames:
+          - tackle-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - tackle.konveyor.io
+          resources:
+          - tackles
+          - tackles/status
+          - tackles/finalizers
+          - addons
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - serviceAccountName: tackle-hub
+        rules:
+        - apiGroups:
+          - ""
+          - tackle.konveyor.io
+          - batch
+          resources:
+          - '*'
+          verbs:
+          - '*'
+      clusterPermissions:
+      - serviceAccountName: tackle-operator
+        rules:
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords: ['modernization', 'konveyor', 'tackle']
+  maintainers:
+  - name: Red Hat
+    email: openshift-operators@redhat.com
+  maturity: beta
+  provider:
+    name: Konveyor
+  links:
+  - name: Konveyor Tackle Documentation
+    url: https://tackle-docs.konveyor.io
+  - name: Konveyor Tackle Operator
+    url: https://github.com/konveyor/tackle2-operator
+  relatedImages:
+  - name: tackle-hub
+    image: quay.io/konveyor/tackle2-hub:{{ release_prefix }}{{ version }}
+  - name: tackle-ui
+    image: quay.io/konveyor/tackle2-ui:{{ release_prefix }}{{ version }}
+  - name: tackle-addon
+    image: quay.io/konveyor/tackle2-addon:{{ release_prefix }}{{ version }}
+  - name: tackle-addon-windup
+    image: quay.io/konveyor/tackle2-addon-windup:{{ release_prefix }}{{ version }}
+  - name: tackle-pathfinder
+    image: quay.io/konveyor/tackle-pathfinder:noauthentication
+  - name: tackle-keycloak
+    image: quay.io/keycloak/keycloak:16.1.1
+  - name: tackle-postgres
+    image: quay.io/centos7/postgresql-12-centos7:latest
+  version: {{ version }}
+  minKubeVersion: 1.20.0

--- a/tools/templates/tackle-k8s.yaml.j2
+++ b/tools/templates/tackle-k8s.yaml.j2
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ namespace }}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: konveyor-tackle
+  namespace: {{ namespace }}
+spec:
+  displayName: Tackle Operator
+  publisher: Konveyor
+  sourceType: grpc
+  image: quay.io/konveyor/tackle2-operator-index:latest
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: konveyor-tackle
+  namespace: {{ namespace }}
+spec:
+  targetNamespaces:
+    - {{ namespace }}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tackle-operator
+  namespace: konveyor-tackle
+spec:
+  channel: {{ channel }}
+  installPlanApproval: Automatic
+  name: tackle-operator
+  source: konveyor-tackle
+  sourceNamespace: {{ namespace }}


### PR DESCRIPTION
- Python tools to re-template all necessary files in order to cut new
  releases upstream

Usage:
```
usage: cut-release.py [-h] --version VERSION [--release_prefix RELEASE_PREFIX] [--channel CHANNEL] [--templates-path TEMPLATES_PATH]
                      [--project-path PROJECT_PATH]

Prepare a new Tackle project release

optional arguments:
  -h, --help            show this help message and exit
  --version VERSION     version must follow semver format (i.e 2.0.0) unless latest
  --release_prefix RELEASE_PREFIX
                        release_prefix is the scheme used for branching project (i.e release-v), default is v
  --channel CHANNEL     OLM channel must follow semver format (i.e release-v2.0), if not supplied will be derived to X.Y from version
  --templates-path TEMPLATES_PATH
                        Absolute path to directory containing jinja2 templates, default is templates
  --project-path PROJECT_PATH
                        Absolute path to directory containing project root, where rendered templates will output, default is CWD

This script is used to prepare a new release branch for Tackle, please review changes before submitting PR.
```