### PR TITLE
Set proxy-body-size default on ingress k8s controllers

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -137,6 +137,7 @@ ui_container_limits_memory: "800Mi"
 ui_container_requests_cpu: "100m"
 ui_container_requests_memory: "350Mi"
 ui_ingress_name: "{{ app_name }}"
+ui_ingress_proxy_body_size: "500m"
 ui_route_name: "{{ app_name }}"
 ui_tls_enabled: false
 ui_route_tls_termination: "edge"

--- a/roles/tackle/templates/ingress-ui.yml.j2
+++ b/roles/tackle/templates/ingress-ui.yml.j2
@@ -2,6 +2,8 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ ui_ingress_proxy_body_size }}
   name: {{ ui_ingress_name }}
   namespace: {{ app_namespace }}
   labels:


### PR DESCRIPTION
- proxy-body-size to 500m to prevent issues with binary uploads in k8s clusters