### PR TITLE
Allow namespace isolation via network policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Please ensure the following requirements are met prior installation.
 * [__Persistent Storage__](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
 * [__Operator Lifecycle Manager (OLM) support__](https://olm.operatorframework.io/)
 * [__Ingress support__](https://kubernetes.io/docs/concepts/services-networking/ingress/)
-
-## Tackle Operator Installation
+* [__Network policy support__](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 
 ### Installing OLM support
 
@@ -34,6 +33,14 @@ We strongly suggest OLM support for Tackle deployments, in some production kuber
 For details and official instructions in how to add OLM support to kubernetes and customize your installation see [here](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md)
 
 **Note:** Please wait a few minutes for OLM support to become available if this is a new deployment.
+
+#### Kubernetes Network Policies
+
+Tackle can provide namespace network isolation if a supported CNI, such as [Calico](https://minikube.sigs.k8s.io/docs/handbook/network_policy/#further-reading), is installed.
+
+`$ minikube start --network-plugin=cni --cni=calico`
+
+## Tackle Operator Installation
 
 ### Installing _released versions_ on k8s
 
@@ -115,6 +122,7 @@ If operator defaults need to be altered, the Tackle CR spec can be customized to
 Name | Default | Description
 --- | --- | ---
 feature_auth_required | true | Enable keycloak auth or false (single user/noauth)
+feature_isolate_namespace | true | Enable namespace isolation via network policies
 hub_database_volume_size | 5Gi | Size requested for Hub database volume
 hub_bucket_volume_size | 100gi | Size requested for Hub bucket volume
 keycloak_database_data_volume_size | 1Gi | Size requested for Keycloak DB volume

--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -115,6 +115,7 @@ spec:
               labels:
                 app: tackle
                 name: tackle-operator
+                role: tackle-operator
             spec:
               serviceAccountName: tackle-operator
               containers:
@@ -198,6 +199,7 @@ spec:
           - networking.k8s.io
           resources:
           - ingresses
+          - networkpolicies
           verbs:
           - '*'
         - apiGroups:
@@ -315,4 +317,4 @@ spec:
   - name: tackle-postgres
     image: quay.io/centos7/postgresql-12-centos7:latest
   version: 99.0.0
-  minKubeVersion: 1.20.0
+  minKubeVersion: 1.22.0

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -5,6 +5,7 @@ app_namespace: "{{ lookup('env', 'WATCH_NAMESPACE') or 'konveyor-tackle' }}"
 # Feature defaults
 feature_ui_enabled: true
 feature_auth_required: true
+feature_isolate_namespace: true
 feature_auth_provider: "keycloak"
 
 openshift_cluster: false

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -294,3 +294,9 @@
       state: present
       definition: "{{ lookup('template', 'customresource-addon-windup.yml.j2') }}"
     when: (windup_cr_status.resources | length) == 0
+
+  - name: "Create Network Policy"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'networkpolicy.yml.j2') }}"
+    when: feature_isolate_namespace|bool

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -30,6 +30,8 @@ spec:
         app.kubernetes.io/name: {{ hub_service_name }}
         app.kubernetes.io/component: {{ hub_component_name }}
         app.kubernetes.io/part-of: {{ app_name }}
+        app: {{ app_name }}
+        role: {{ hub_service_name }}
     spec:
       serviceAccountName: {{ hub_serviceaccount_name }}
       containers:

--- a/roles/tackle/templates/deployment-keycloak-postgresql.yml.j2
+++ b/roles/tackle/templates/deployment-keycloak-postgresql.yml.j2
@@ -23,6 +23,8 @@ spec:
         app.kubernetes.io/name: {{ keycloak_database_service_name }}
         app.kubernetes.io/component: {{ keycloak_database_component_name }}
         app.kubernetes.io/part-of: {{ app_name }}
+        app: {{ app_name }}
+        role: {{ keycloak_database_service_name }}
     spec:
       containers:
         - name: {{ keycloak_database_container_name }}

--- a/roles/tackle/templates/deployment-keycloak-sso.yml.j2
+++ b/roles/tackle/templates/deployment-keycloak-sso.yml.j2
@@ -27,6 +27,8 @@ spec:
         app.kubernetes.io/name: {{ keycloak_sso_service_name }}
         app.kubernetes.io/component: {{ keycloak_sso_component_name }}
         app.kubernetes.io/part-of: {{ app_name }}
+        app: {{ app_name }}
+        role: {{ keycloak_sso_service_name }}
     spec:
       initContainers:
         - name: keycloak-theme

--- a/roles/tackle/templates/deployment-pathfinder-postgresql.yml.j2
+++ b/roles/tackle/templates/deployment-pathfinder-postgresql.yml.j2
@@ -23,6 +23,8 @@ spec:
         app.kubernetes.io/name: {{ pathfinder_database_service_name }}
         app.kubernetes.io/component: {{ pathfinder_database_component_name }}
         app.kubernetes.io/part-of: {{ app_name }}
+        app: {{ app_name }}
+        role: {{ pathfinder_database_service_name }}
     spec:
       containers:
         - name: {{ pathfinder_database_container_name }}

--- a/roles/tackle/templates/deployment-pathfinder.yml.j2
+++ b/roles/tackle/templates/deployment-pathfinder.yml.j2
@@ -33,6 +33,8 @@ spec:
         app.kubernetes.io/name: {{ pathfinder_service_name }}
         app.kubernetes.io/component: {{ pathfinder_component_name }}
         app.kubernetes.io/part-of: {{ app_name }}
+        app: {{ app_name }}
+        role: {{ pathfinder_service_name }}
       annotations:
         prometheus.io/path: /q/metrics
         prometheus.io/port: '8080'

--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -30,6 +30,8 @@ spec:
         app.kubernetes.io/name: {{ ui_service_name }}
         app.kubernetes.io/component: {{ ui_component_name }}
         app.kubernetes.io/part-of: {{ app_name }}
+        app: {{ app_name }}
+        role: {{ ui_service_name }}
     spec:
       containers:
         - name: {{ ui_container_name }}

--- a/roles/tackle/templates/ingress-ui.yml.j2
+++ b/roles/tackle/templates/ingress-ui.yml.j2
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/name: {{ ui_ingress_name }}
     app.kubernetes.io/component: ingress
     app.kubernetes.io/part-of: {{ app_name }}
+    app: {{ app_name }}
 spec:
   ingressClassName: nginx
   tls:

--- a/roles/tackle/templates/networkpolicy.yml.j2
+++ b/roles/tackle/templates/networkpolicy.yml.j2
@@ -1,0 +1,15 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ app_name }}-ingress
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ app_namespace }}

--- a/roles/tackle/templates/route-ui.yml.j2
+++ b/roles/tackle/templates/route-ui.yml.j2
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/name: {{ ui_service_name }}
     app.kubernetes.io/component: route
     app.kubernetes.io/part-of: {{ app_name }}
+    app: {{ app_name }}
 spec:
   to:
     kind: Service


### PR DESCRIPTION
- Implement namespace isolation via network policies, by default feature is turned on. OCP has support for network policies by default in OpenShift SDN , in k8s clusters calico can be installed
- Policy allows ingress traffic to all ports from any pod that lives in the Tackle namespace, blocks all other ingress traffic
- Enforcement of policy via immutable namespace label kubernetes.io/metadata.name=<namespace>
- If the cluster lacks support for k8s network policies , the policy will not have any effect
- Bumped minKubeVersion to v1.22.0 for network policy feature compatibility
- Tested on OCP v4.10 and minikube v1.24 w/ calico