### PR TITLE
PATHFINDER_URL moved to hub.

### DIFF
--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -83,6 +83,12 @@ spec:
                   key: addon_token
             - name: AUTH_REQUIRED
               value: '{{ feature_auth_required|lower }}'
+            - name: PATHFINDER_URL
+{% if pathfinder_tls_enabled|bool %}
+              value: "http://{{ pathfinder_service_name }}:8443"
+{% else %}
+              value: "http://{{ pathfinder_service_name }}:8080"
+{% endif %}
 {% if feature_auth_required|bool %}
             - name: KEYCLOAK_REALM
               value: "{{ keycloak_sso_realm }}"

--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -46,12 +46,6 @@ spec:
 {% else %}
               value: "http://{{ hub_service_name }}:8080"
 {% endif %}
-            - name: PATHFINDER_URL
-{% if pathfinder_tls_enabled|bool %}
-              value: "http://{{ pathfinder_service_name }}:8443"
-{% else %}
-              value: "http://{{ pathfinder_service_name }}:8080"
-{% endif %}
             - name: AUTH_REQUIRED
               value: "{{ feature_auth_required|lower }}"
 {% if feature_auth_required|bool %}


### PR DESCRIPTION
Needed by the Hub.  No longer used by the UI.

Needs to be coordinated with hub and UI PRs.