### PR TITLE
Allow external UI access via network policy

### DIFF
--- a/roles/tackle/templates/networkpolicy.yml.j2
+++ b/roles/tackle/templates/networkpolicy.yml.j2
@@ -1,8 +1,20 @@
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ app_name }}-deny-all
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: {{ app_name }}-ingress
+  name: {{ app_name }}-namespace
   namespace: {{ app_namespace }}
   labels:
     app: {{ app_name }}
@@ -13,3 +25,19 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: {{ app_namespace }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ app_name }}-external
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      role: tackle-ui
+  ingress:
+  - ports:
+    - port: 8080
+    - port: 8443


### PR DESCRIPTION
**Network policy updates**

* tackle-default-deny : explicitly denies all ingress traffic to all pods in tackle namespace from any source
* tackle-namespace : allows ingress traffic from any pod in the tackle namespace to all ports
* tackle-external : allows ingress traffic from any pod to the tackle UI pod on ports 8080 and 8443

I have left the feature namespace isolation off by default until the policy gets more mileage.
