### PR TITLE
Revert "TACKLE-604: Add migrator to assessments scopes"

### DIFF
--- a/roles/tackle/templates/configmap-keycloak-sso.yml.j2
+++ b/roles/tackle/templates/configmap-keycloak-sso.yml.j2
@@ -1015,16 +1015,14 @@ data:
           "clientScope": "assessments:post",
           "roles": [
             "tackle-architect",
-            "tackle-admin",
-            "tackle-migrator"
+            "tackle-admin"
           ]
         },
         {
           "clientScope": "assessments:put",
           "roles": [
             "tackle-architect",
-            "tackle-admin",
-            "tackle-migrator"
+            "tackle-admin"
           ]
         },
         {
@@ -1038,8 +1036,7 @@ data:
           "clientScope": "assessments:delete",
           "roles": [
             "tackle-architect",
-            "tackle-admin",
-            "tackle-migrator"
+            "tackle-admin"
           ]
         },
         {


### PR DESCRIPTION
Reverts konveyor/tackle2-operator#80

This should fix https://issues.redhat.com/browse/TACKLE-641