### PR TITLE
Rename component image ENV vars

### DIFF
--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -131,21 +131,21 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: ANSIBLE_GATHERING
                   value: explicit
-                - name: TACKLE_HUB_IMAGE
+                - name: RELATED_IMAGE_TACKLE_HUB
                   value: quay.io/konveyor/tackle2-hub:latest
-                - name: PATHFINDER_DATABASE_IMAGE
+                - name: RELATED_IMAGE_PATHFINDER_DATABASE
                   value: quay.io/centos7/postgresql-12-centos7:latest
-                - name: PATHFINDER_IMAGE
+                - name: RELATED_IMAGE_PATHFINDER
                   value: quay.io/konveyor/tackle-pathfinder:1.3.0-native
-                - name: KEYCLOAK_DATABASE_IMAGE
+                - name: RELATED_IMAGE_KEYCLOAK_DATABASE
                   value: quay.io/centos7/postgresql-12-centos7:latest
-                - name: KEYCLOAK_SSO_IMAGE
+                - name: RELATED_IMAGE_KEYCLOAK_SSO
                   value: quay.io/keycloak/keycloak:16.1.1
-                - name: TACKLE_UI_IMAGE
+                - name: RELATED_IMAGE_TACKLE_UI
                   value: quay.io/konveyor/tackle2-ui:latest
-                - name: ADDON_ADMIN_IMAGE
+                - name: RELATED_IMAGE_ADDON_ADMIN
                   value: quay.io/konveyor/tackle2-addon:latest
-                - name: ADDON_WINDUP_IMAGE
+                - name: RELATED_IMAGE_ADDON_WINDUP
                   value: quay.io/konveyor/tackle2-addon-windup:latest
                 name: tackle-operator
                 image: quay.io/konveyor/tackle2-operator:latest

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -17,7 +17,7 @@ tackle_resources:
   - "Secret"
   - "Route"
 
-hub_image_fqin: "{{ lookup('env', 'TACKLE_HUB_IMAGE') }}"
+hub_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_TACKLE_HUB') }}"
 hub_component_name: "hub"
 hub_service_name: "{{ app_name }}-{{ hub_component_name }}"
 hub_serviceaccount_name: "{{ app_name }}-hub"
@@ -48,7 +48,7 @@ hub_tls_enabled: false
 hub_tls_secret_name: "{{ hub_service_name }}-serving-cert"
 hub_log_level: 3
 
-pathfinder_database_image_fqin: "{{ lookup('env', 'PATHFINDER_DATABASE_IMAGE') }}"
+pathfinder_database_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_PATHFINDER_DATABASE') }}"
 pathfinder_database_name: "pathfinder"
 pathfinder_database_component_name: "postgresql"
 pathfinder_database_service_name: "{{ app_name }}-{{ pathfinder_database_name }}-{{ pathfinder_database_component_name }}"
@@ -68,7 +68,7 @@ pathfinder_database_data_volume_claim_name: "{{ pathfinder_database_service_name
 pathfinder_database_db_name: "pathfinder_db"
 pathfinder_database_db_name_b64: "{{ pathfinder_database_db_name | b64encode }}"
 
-pathfinder_image_fqin: "{{ lookup('env', 'PATHFINDER_IMAGE') }}"
+pathfinder_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_PATHFINDER') }}"
 pathfinder_component_name: "pathfinder"
 pathfinder_service_name: "{{ app_name }}-{{ pathfinder_component_name }}"
 pathfinder_deployment_name: "{{ pathfinder_service_name }}"
@@ -81,7 +81,7 @@ pathfinder_container_requests_memory: "350Mi"
 pathfinder_tls_enabled: false
 pathfinder_tls_secret_name: "{{ pathfinder_service_name }}-serving-cert"
 
-keycloak_database_image_fqin: "{{ lookup('env', 'KEYCLOAK_DATABASE_IMAGE') }}"
+keycloak_database_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_KEYCLOAK_DATABASE') }}"
 keycloak_database_name: "keycloak"
 keycloak_database_component_name: "postgresql"
 keycloak_database_service_name: "{{ app_name }}-{{ keycloak_database_name }}-{{ keycloak_database_component_name }}"
@@ -101,7 +101,7 @@ keycloak_database_data_volume_claim_name: "{{ keycloak_database_service_name }}-
 keycloak_database_db_name: "keycloak_db"
 keycloak_database_db_name_b64: "{{ keycloak_database_db_name | b64encode }}"
 
-keycloak_sso_image_fqin: "{{ lookup('env', 'KEYCLOAK_SSO_IMAGE') }}"
+keycloak_sso_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_KEYCLOAK_SSO') }}"
 keycloak_sso_name: "keycloak"
 keycloak_sso_component_name: "sso"
 keycloak_sso_service_name: "{{ app_name }}-{{ keycloak_sso_name }}-{{ keycloak_sso_component_name }}"
@@ -127,7 +127,7 @@ keycloak_sso_req_passwd_update: true
 keycloak_sso_hub_client_id: "tackle-hub"
 keycloak_sso_hub_client_secret: "tackle"
 
-ui_image_fqin: "{{ lookup('env', 'TACKLE_UI_IMAGE') }}"
+ui_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_TACKLE_UI') }}"
 ui_component_name: "ui"
 ui_service_name: "{{ app_name }}-{{ ui_component_name }}"
 ui_configmap_name: "{{ ui_service_name }}-config"
@@ -146,14 +146,14 @@ ui_route_tls_termination: "edge"
 ui_route_tls_insecure_termination_policy: "Redirect"
 ui_tls_secret_name: "{{ ui_service_name }}-serving-cert"
 
-admin_fqin: "{{ lookup('env', 'ADDON_ADMIN_IMAGE') }}"
+admin_fqin: "{{ lookup('env', 'RELATED_IMAGE_ADDON_ADMIN') }}"
 admin_name: "admin"
 admin_component_name: "addon"
 admin_service_name: "{{ app_name }}-{{ admin_name }}-{{ admin_component_name }}"
 admin_container_requests_cpu: "50m"
 admin_container_requests_memory: "50Mi"
 
-windup_fqin: "{{ lookup('env', 'ADDON_WINDUP_IMAGE') }}"
+windup_fqin: "{{ lookup('env', 'RELATED_IMAGE_ADDON_WINDUP') }}"
 windup_name: "windup"
 windup_component_name: "addon"
 windup_service_name: "{{ app_name }}-{{ windup_name }}-{{ windup_component_name }}"

--- a/tools/templates/clusterserviceversion.yaml.j2
+++ b/tools/templates/clusterserviceversion.yaml.j2
@@ -131,21 +131,21 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: ANSIBLE_GATHERING
                   value: explicit
-                - name: TACKLE_HUB_IMAGE
+                - name: RELATED_IMAGE_TACKLE_HUB
                   value: quay.io/konveyor/tackle2-hub:{{ tag }}
-                - name: PATHFINDER_DATABASE_IMAGE
+                - name: RELATED_IMAGE_PATHFINDER_DATABASE
                   value: quay.io/centos7/postgresql-12-centos7:latest
-                - name: PATHFINDER_IMAGE
+                - name: RELATED_IMAGE_PATHFINDER
                   value: quay.io/konveyor/tackle-pathfinder:1.3.0-native
-                - name: KEYCLOAK_DATABASE_IMAGE
+                - name: RELATED_IMAGE_KEYCLOAK_DATABASE
                   value: quay.io/centos7/postgresql-12-centos7:latest
-                - name: KEYCLOAK_SSO_IMAGE
+                - name: RELATED_IMAGE_KEYCLOAK_SSO
                   value: quay.io/keycloak/keycloak:16.1.1
-                - name: TACKLE_UI_IMAGE
+                - name: RELATED_IMAGE_TACKLE_UI
                   value: quay.io/konveyor/tackle2-ui:{{ tag }}
-                - name: ADDON_ADMIN_IMAGE
+                - name: RELATED_IMAGE_ADDON_ADMIN
                   value: quay.io/konveyor/tackle2-addon:{{ tag }}
-                - name: ADDON_WINDUP_IMAGE
+                - name: RELATED_IMAGE_ADDON_WINDUP
                   value: quay.io/konveyor/tackle2-addon-windup:{{ tag }}
                 name: tackle-operator
                 image: quay.io/konveyor/tackle2-operator:{{ tag }}


### PR DESCRIPTION
- Rename image environmental vars to comply with OSBS SHA pinning naming scheme
- Requires re-deployment as operator and OLM metadata has changed