### PR TITLE
ci(actions): start minikube & install tackle

### DIFF
--- a/.github/actions/install-tackle/action.yml
+++ b/.github/actions/install-tackle/action.yml
@@ -1,0 +1,49 @@
+name: Install tackle operator
+description: |
+  Install Tackle Operator.
+inputs: 
+  tackle-operator-index-image:
+    description: "image url for operator index"
+    required: false
+    default: "quay.io/konveyor/tackle2-operator-index:latest"
+  tackle-hub-image:
+    description: "image url for tackle-hub"
+    required: false
+    default: "quay.io/konveyor/tackle2-hub:latest"
+  tackle-pathfinder-image:
+    description: "image url for pathfinder image"
+    required: false
+    default: "quay.io/konveyor/tackle-pathfinder:1.3.0-native"
+  tackle-ui-image:
+    description: "image url for tackle-ui"
+    required: false
+    default: "quay.io/konveyor/tackle2-ui:latest"
+  tackle-addon-admin-image:
+    description: "image urd for admin addon"
+    required: false
+    default: "quay.io/konveyor/tackle2-addon:latest"
+  tackle-addon-windup-image:
+    description: "image url for windup addon"
+    required: false
+    default: "quay.io/konveyor/tackle2-addon-windup:latest"
+  # TODO(djzager): uncomment when supported
+  # tackle-operator-container-image:
+  #   description: "image url for operator container"
+  #   required: false
+  #   default: "quay.io/konveyor/tackle2-operator:latest"
+runs:
+  using: "composite"
+  steps:
+  # TODO(djzager): Need to figure out overriding operator image
+  # or maybe just installing manager via kustomize.
+  - name: Install tackle
+    run: |
+      export TACKLE_OPERATOR_INDEX_IMAGE="${{ inputs.tackle-operator-index-image }}"
+      export TACKLE_HUB_IMAGE="${{ inputs.tackle_hub_image }}"
+      export TACKLE_PATHFINDER_IMAGE="${{ inputs.tackle_pathfinder_image }}"
+      export TACKLE_UI_IMAGE="${{ inputs.tackle_ui_image }}"
+      export TACKLE_ADDON_ADMIN_IMAGE="${{ inputs.tackle_addon_admin_image }}"
+      export TACKLE_ADDON_WINDUP_IMAGE="${{ inputs.tackle_addon_windup_image }}"
+      make install-tackle
+    working-directory: ${{ github.action_path }}/../../..
+    shell: bash

--- a/.github/actions/start-minikube/action.yml
+++ b/.github/actions/start-minikube/action.yml
@@ -1,0 +1,45 @@
+name: Start minikube
+description: |
+  Start minikube and prepare it for Tackle.
+inputs:
+  driver:
+    description: 'Choose a specific driver, one of: docker, none, podman, virtualbox, parallels, vmwarefusion, hyperkit, vmware, ssh'
+    required: false
+    default: ''
+  container-runtime:
+    description: 'Choose a specific container-runtime, one of: docker, containerd, cri-o'
+    required: false
+    default: ''
+  kubernetes-version:
+    description: 'Choose a specific version of Kubernetes, "stable" for the latest stable build, or "latest" for the latest development build'
+    required: false
+    default: ''
+  cpus:
+    description: 'Number of CPUs allocated to Kubernetes. Use "max" to use the maximum number of CPUs.'
+    required: false
+    default: ''
+  memory:
+    description: 'Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g). Use "max" to use the maximum amount of memory.'
+    required: false
+    default: ''
+  cni:
+    description: 'CNI plug-in to use. Valid options: auto, bridge, calico, cilium, flannel, kindnet, or path to a CNI manifest'
+    required: false
+    default: 'auto'
+runs:
+  using: "composite"
+  steps:
+  - name: Setup minikube
+    uses: medyagh/setup-minikube@master
+    with:
+      driver: ${{ inputs.driver }}
+      container-runtime: ${{ inputs.container-runtime }}
+      kubernetes-version: ${{ inputs.kubernetes-version }}
+      cpus: ${{ inputs.cpus }}
+      memory: ${{ inputs.memory }}
+      cni: ${{ inputs.cni }}
+  # Don't pass minikube start ${ARGS} as they are handled in setup-minikube
+  - name: Start minikube
+    run: make start-minikube
+    working-directory: ${{ github.action_path }}/../../..
+    shell: bash

--- a/Makefile
+++ b/Makefile
@@ -192,3 +192,11 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+.PHONY: start-minikube
+start-minikube:
+	export PATH=$(shell pwd)/bin:$$PATH; $(shell pwd)/hack/start-minikube.sh
+
+.PHONY: install-tackle
+install-tackle:
+	export PATH=$(shell pwd)/bin:$$PATH; $(shell pwd)/hack/install-tackle.sh

--- a/hack/install-tackle.sh
+++ b/hack/install-tackle.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -e
+set -x
+
+TACKLE_OPERATOR_INDEX_IMAGE="${TACKLE_OPERATOR_INDEX_IMAGE:-quay.io/konveyor/tackle2-operator-index:latest}"
+TACKLE_HUB_IMAGE="${TACKLE_HUB_IMAGE:-quay.io/konveyor/tackle2-hub:latest}"
+TACKLE_PATHFINDER_IMAGE="${TACKLE_PATHFINDER_IMAGE:-quay.io/konveyor/tackle-pathfinder:1.3.0-native}"
+TACKLE_UI_IMAGE="${TACKLE_UI_IMAGE:-quay.io/konveyor/tackle2-ui:latest}"
+TACKLE_ADDON_ADMIN_IMAGE="${TACKLE_ADDON_ADMIN_IMAGE:-quay.io/konveyor/tackle2-addon:latest}"
+TACKLE_ADDON_WINDUP_IMAGE="${TACKLE_ADDON_WINDUP_IMAGE:-quay.io/konveyor/tackle2-addon-windup:latest}"
+
+TACKLE_FEATURE_AUTH_REQUIRED="${TACKLE_FEATURE_AUTH_REQUIRED:-false}"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "Please install kubectl"
+  exit 1
+fi
+
+# Create namespace
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: konveyor-tackle
+EOF
+
+# Create catalogsource
+cat << EOF | kubectl apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: konveyor-tackle
+  namespace: konveyor-tackle
+spec:
+  displayName: Tackle Operator
+  publisher: Konveyor
+  sourceType: grpc
+  image: ${TACKLE_OPERATOR_INDEX_IMAGE}
+EOF
+
+# Create operatorgroup
+cat << EOF | kubectl apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: konveyor-tackle
+  namespace: konveyor-tackle
+spec:
+  targetNamespaces:
+    - konveyor-tackle
+EOF
+
+# Create, and wait for, subscription
+cat << EOF | kubectl apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tackle-operator
+  namespace: konveyor-tackle
+spec:
+  channel: development
+  installPlanApproval: Automatic
+  name: tackle-operator
+  source: konveyor-tackle
+  sourceNamespace: konveyor-tackle
+EOF
+timeout 600s bash -c 'until kubectl get customresourcedefinitions.apiextensions.k8s.io tackles.tackle.konveyor.io; do sleep 30; done'
+
+# Create, and wait for, tackle
+kubectl wait \
+  --namespace konveyor-tackle \
+  --for=condition=established \
+  customresourcedefinitions.apiextensions.k8s.io/tackles.tackle.konveyor.io
+cat <<EOF | kubectl apply -f -
+kind: Tackle
+apiVersion: tackle.konveyor.io/v1alpha1
+metadata:
+  name: tackle
+  namespace: konveyor-tackle
+spec:
+  feature_auth_required: ${TACKLE_FEATURE_AUTH_REQUIRED}
+  hub_image_fqin: ${TACKLE_HUB_IMAGE}
+  pathfinder_image_fqin: ${TACKLE_PATHFINDER_IMAGE}
+  ui_image_fqin: ${TACKLE_UI_IMAGE}
+  admin_fqin: ${TACKLE_ADDON_ADMIN_IMAGE}
+  windup_fqin: ${TACKLE_ADDON_WINDUP_IMAGE}
+EOF
+# Wait for reconcile to finish
+kubectl wait \
+  --namespace konveyor-tackle \
+  --for=condition=Successful \
+  --timeout=600s \
+  tackles.tackle.konveyor.io/tackle
+
+# Now wait for all the tackle deployments
+kubectl wait \
+  --namespace konveyor-tackle \
+  --selector="app.kubernetes.io/part-of=tackle" \
+  --for=condition=Available \
+  --timeout=600s \
+  deployments.apps

--- a/hack/start-minikube.sh
+++ b/hack/start-minikube.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+set -x
+
+# Inputs via environment variables
+MINIKUBE_DRIVER="${MINIKUBE_DRIVER:-}"
+MINIKUBE_CONTAINER_RUNTIME="${MINIKUBE_CONTAINER_RUNTIME:-}"
+MINIKUBE_KUBERNETES_VERSION="${MINIKUBE_KUBERNETES_VERSION:-}"
+MINIKUBE_CPUS="${MINIKUBE_CPUS:-}"
+MINIKUBE_MEMORY="${MINIKUBE_MEMORY:-}"
+MINIKUBE_CNI="${MINIKUBE_CNI:-}"
+
+# Check pre-reqs
+# May want to leave this for the user to install
+if ! command -v minikube >/dev/null 2>&1; then
+  echo "Please install minikube"
+  exit 1
+fi
+
+# Start minikube if not already started
+if ! minikube status; then
+  ARGS=""
+  [ -z "${MINIKUBE_DRIVER}" ] || \
+    ARGS+=" --driver=${MINIKUBE_DRIVER}"
+  [ -z "${MINIKUBE_CONTAINER_RUNTIME}" ] || \
+    ARGS+=" --container-runtime=${MINIKUBE_CONTAINER_RUNTIME}"
+  [ -z "${MINIKUBE_KUBERNETES_VERSION}" ] || \
+    ARGS+=" --kubernetes-version=${MINIKUBE_KUBERNETES_VERSION}"
+  [ -z "${MINIKUBE_CPUS}" ] || \
+    ARGS+=" --cpus=${MINIKUBE_CPUS}"
+  [ -z "${MINIKUBE_MEMORY}" ] || \
+    ARGS+=" --memory=${MINIKUBE_MEMORY}"
+  [ -z "${MINIKUBE_CNI}" ] || \
+    ARGS+=" --cni=${MINIKUBE_CNI}"
+  set -x
+  minikube start ${ARGS}
+fi
+
+# Enable ingress
+minikube addons enable ingress
+
+# Enable, and wait for, OLM
+minikube addons enable olm
+kubectl wait \
+  --namespace olm \
+  --for=condition=Available \
+  --timeout=300s \
+  --all deployments.apps


### PR DESCRIPTION
This is the first PR with the goal leveraging GitHub Actions to provide the Konveyor organization with a simple and extensible CI/CD platform. Here is a [link to the Google Slides](https://docs.google.com/presentation/d/1l9BObaU7tSO9OXQw5CCs_ziyJIexw6qxZi-o2wRtNVc) where this was presented in the [Konveyor Technical Architecture Forum](https://docs.google.com/document/d/1Z_i9Qzxn8GST5b6aU_-IUBY4fcd13YCwCsfEqOnAff8/edit#heading=h.ddgaq7lqxzdk).

**tl;dr**

* This PR introduces 2 GitHub Actions (`start-minikube` and `install-tackle`)
* These actions are run via shell scripts that can be invoked via Makefile for local development
* Shell scripts are intentionally made to be self-contained (no `source utils.sh`) and idempotent (`kubectl apply` instead of `kubectl create`) to make them useful for local development
* These actions (and shell scripts) can be re-used in other Tackle projects that need them for testing (ie. `tackle2-addon-windup`)

The end goal is to make these scripts useful in the typical development workflow to simplify onboarding new contributors by having well used/tested startup scripts.