### PR TITLE
Implement PROFILE and VERSION

### DIFF
--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     support: https://github.com/konveyor/tackle2-operator/issues
     repository: https://github.com/konveyor/tackle2-operator
     certified: "false"
-    containerImage: quay.io/konveyor/tackle2-operator:latest
+    containerImage: quay.io/fbladilo/tackle2-operator:latest
     createdAt: 2022-07-07
     olm.skipRange: '>=0.0.0 <99.0.0'
     alm-examples: |-
@@ -131,6 +131,10 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: ANSIBLE_GATHERING
                   value: explicit
+                - name: PROFILE
+                  value: konveyor
+                - name: VERSION
+                  value: 99.0.0
                 - name: RELATED_IMAGE_TACKLE_HUB
                   value: quay.io/konveyor/tackle2-hub:latest
                 - name: RELATED_IMAGE_PATHFINDER_DATABASE
@@ -148,7 +152,7 @@ spec:
                 - name: RELATED_IMAGE_ADDON_WINDUP
                   value: quay.io/konveyor/tackle2-addon-windup:latest
                 name: tackle-operator
-                image: quay.io/konveyor/tackle2-operator:latest
+                image: quay.io/fbladilo/tackle2-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     support: https://github.com/konveyor/tackle2-operator/issues
     repository: https://github.com/konveyor/tackle2-operator
     certified: "false"
-    containerImage: quay.io/fbladilo/tackle2-operator:latest
+    containerImage: quay.io/konveyor/tackle2-operator:latest
     createdAt: 2022-07-07
     olm.skipRange: '>=0.0.0 <99.0.0'
     alm-examples: |-
@@ -152,7 +152,7 @@ spec:
                 - name: RELATED_IMAGE_ADDON_WINDUP
                   value: quay.io/konveyor/tackle2-addon-windup:latest
                 name: tackle-operator
-                image: quay.io/fbladilo/tackle2-operator:latest
+                image: quay.io/konveyor/tackle2-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
+# App defaults
 app_name: "{{ lookup('env', 'APP_NAME') or 'tackle' }}"
 app_namespace: "{{ lookup('env', 'WATCH_NAMESPACE') or 'konveyor-tackle' }}"
+app_profile: "{{ lookup('env', 'PROFILE') }}"
+app_version: "{{ lookup('env', 'VERSION') }}"
 
 # Feature defaults
 feature_ui_enabled: true
@@ -17,6 +20,7 @@ tackle_resources:
   - "Secret"
   - "Route"
 
+# Components
 hub_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_TACKLE_HUB') }}"
 hub_component_name: "hub"
 hub_service_name: "{{ app_name }}-{{ hub_component_name }}"

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -44,6 +44,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: PROFILE
+              value: "{{ app_profile }}"
+            - name: VERSION
+              value: "{{ app_version }}"
 {% if hub_tls_enabled|bool %}
             - name: HUB_TLS_ENABLED
               value: 'true'

--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -38,6 +38,10 @@ spec:
           image: "{{ ui_image_fqin }}"
           imagePullPolicy: "{{ image_pull_policy }}"
           env:
+            - name: PROFILE
+              value: "{{ app_profile }}"
+            - name: VERSION
+              value: "{{ app_version }}"
             - name: UI_INGRESS_PROXY_BODY_SIZE
               value: '{{ui_ingress_proxy_body_size}}'
             - name: TACKLE_HUB_URL

--- a/tools/templates/clusterserviceversion.yaml.j2
+++ b/tools/templates/clusterserviceversion.yaml.j2
@@ -131,6 +131,10 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: ANSIBLE_GATHERING
                   value: explicit
+                - name: PROFILE
+                  value: konveyor
+                - name: VERSION
+                  value: {{ version }}
                 - name: RELATED_IMAGE_TACKLE_HUB
                   value: quay.io/konveyor/tackle2-hub:{{ tag }}
                 - name: RELATED_IMAGE_PATHFINDER_DATABASE


### PR DESCRIPTION
This PR should aid Tackle components to identify what profile and version of Tackle is deployed, this allows us to act accordingly to different use cases, (i.e upstream or downstream). The operator will expose environment variables to UI and HUB pods as PROFILE and VERSION. The authoritative source for these values is the Operator Bundle CSV.

Summary of changes below:

- PROFILE and VERSION defined in the Operator CSV and sourced by ansible operator as app_profile and app_version
- Valid values for PROFILE are **konveyor** or **mta** , default value for Tackle is **konveyor**.
- Tackle release tools also updated to account for these new environmental vars

