### PR TITLE
Upgrade keycloak to v18

### DIFF
--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     support: https://github.com/konveyor/tackle2-operator/issues
     repository: https://github.com/konveyor/tackle2-operator
     certified: "false"
-    containerImage: quay.io/fbladilo/tackle2-operator:latest
+    containerImage: quay.io/konveyor/tackle2-operator:latest
     createdAt: 2022-07-07
     olm.skipRange: '>=0.0.0 <99.0.0'
     alm-examples: |-
@@ -152,7 +152,7 @@ spec:
                 - name: RELATED_IMAGE_ADDON_WINDUP
                   value: quay.io/konveyor/tackle2-addon-windup:latest
                 name: tackle-operator
-                image: quay.io/fbladilo/tackle2-operator:latest
+                image: quay.io/konveyor/tackle2-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     support: https://github.com/konveyor/tackle2-operator/issues
     repository: https://github.com/konveyor/tackle2-operator
     certified: "false"
-    containerImage: quay.io/konveyor/tackle2-operator:latest
+    containerImage: quay.io/fbladilo/tackle2-operator:latest
     createdAt: 2022-07-07
     olm.skipRange: '>=0.0.0 <99.0.0'
     alm-examples: |-
@@ -144,7 +144,7 @@ spec:
                 - name: RELATED_IMAGE_KEYCLOAK_DATABASE
                   value: quay.io/centos7/postgresql-12-centos7:latest
                 - name: RELATED_IMAGE_KEYCLOAK_SSO
-                  value: quay.io/keycloak/keycloak:16.1.1
+                  value: quay.io/keycloak/keycloak:18.0.2-legacy
                 - name: RELATED_IMAGE_TACKLE_UI
                   value: quay.io/konveyor/tackle2-ui:latest
                 - name: RELATED_IMAGE_ADDON_ADMIN
@@ -152,7 +152,7 @@ spec:
                 - name: RELATED_IMAGE_ADDON_WINDUP
                   value: quay.io/konveyor/tackle2-addon-windup:latest
                 name: tackle-operator
-                image: quay.io/konveyor/tackle2-operator:latest
+                image: quay.io/fbladilo/tackle2-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -330,7 +330,7 @@ spec:
   - name: tackle-pathfinder
     image: quay.io/konveyor/tackle-pathfinder:1.3.0-native
   - name: tackle-keycloak
-    image: quay.io/keycloak/keycloak:16.1.1
+    image: quay.io/keycloak/keycloak:18.0.2-legacy
   - name: tackle-postgres
     image: quay.io/centos7/postgresql-12-centos7:latest
   version: 99.0.0

--- a/tools/templates/clusterserviceversion.yaml.j2
+++ b/tools/templates/clusterserviceversion.yaml.j2
@@ -144,7 +144,7 @@ spec:
                 - name: RELATED_IMAGE_KEYCLOAK_DATABASE
                   value: quay.io/centos7/postgresql-12-centos7:latest
                 - name: RELATED_IMAGE_KEYCLOAK_SSO
-                  value: quay.io/keycloak/keycloak:16.1.1
+                  value: quay.io/keycloak/keycloak:18.0.2-legacy
                 - name: RELATED_IMAGE_TACKLE_UI
                   value: quay.io/konveyor/tackle2-ui:{{ tag }}
                 - name: RELATED_IMAGE_ADDON_ADMIN
@@ -330,7 +330,7 @@ spec:
   - name: tackle-pathfinder
     image: quay.io/konveyor/tackle-pathfinder:1.3.0-native
   - name: tackle-keycloak
-    image: quay.io/keycloak/keycloak:16.1.1
+    image: quay.io/keycloak/keycloak:18.0.2-legacy
   - name: tackle-postgres
     image: quay.io/centos7/postgresql-12-centos7:latest
   version: {{ version }}


### PR DESCRIPTION
- Align upstream keycloak release with RHSSO 7.6 (based on v18)
- Targeted for 2.1.2

References in RHSSO 7.6 announcement : 

[RHSSO 7.6](https://access.redhat.com/announcements/6965643)
