### PR TITLE
Add NODE_EXTRA_CA_CERTS support to UI deployment

### DIFF
--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -296,6 +296,7 @@ spec:
           - config.openshift.io
           resources:
           - clusterversions
+          - proxies
           verbs:
           - get
   installModes:

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -146,6 +146,7 @@ ui_ingress_name: "{{ app_name }}"
 ui_ingress_proxy_body_size: "500m"
 ui_route_name: "{{ app_name }}"
 ui_tls_enabled: false
+ui_node_extra_ca_certs: "/opt/app-root/src/ca.crt"
 ui_route_tls_termination: "edge"
 ui_route_tls_insecure_termination_policy: "Redirect"
 ui_tls_secret_name: "{{ ui_service_name }}-serving-cert"

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -22,20 +22,20 @@
 
   - when: openshift_cluster|bool
     block:
-    - name: "Get OpenShift cluster Proxy object"
-      set_fact:
-        proxy_cluster: "{{ lookup('k8s', api_version='config.openshift.io/v1', kind='Proxy', resource_name='cluster') }}"
+      - name: "Get OpenShift cluster Proxy object"
+        set_fact:
+          proxy_cluster: "{{ lookup('k8s', api_version='config.openshift.io/v1', kind='Proxy', resource_name='cluster') }}"
 
-    - when: (proxy_cluster.spec.trustedCA.name | length) > 0
-      block:
-        - name: "Enable trusted CA environment"
-          set_fact:
-            trusted_ca_enabled: true
+      - when: (proxy_cluster.spec.trustedCA.name | length) > 0
+        block:
+          - name: "Enable trusted CA environment"
+            set_fact:
+              trusted_ca_enabled: true
 
-        - name: "Create an empty ConfigMap that will hold the trusted CA"
-          k8s:
-            state: present
-            definition: "{{ lookup('template', 'configmap-trusted-ca.yml.j2') }}"
+          - name: "Create an empty ConfigMap that will hold the trusted CA"
+            k8s:
+              state: present
+              definition: "{{ lookup('template', 'configmap-trusted-ca.yml.j2') }}"
 
   - when:
       - feature_auth_required|bool

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -20,6 +20,23 @@
         set_fact:
           k8s_cluster_version: "{{ lookup('k8s', cluster_info='version').kubernetes.gitVersion }}"
 
+  - when: openshift_cluster|bool
+    block:
+    - name: "Get OpenShift cluster Proxy object"
+      set_fact:
+        proxy_cluster: "{{ lookup('k8s', api_version='config.openshift.io/v1', kind='Proxy', resource_name='cluster') }}"
+
+    - when: (proxy_cluster.spec.trustedCA.name | length) > 0
+      block:
+        - name: "Enable trusted CA environment"
+          set_fact:
+            trusted_ca_enabled: true
+
+        - name: "Create an empty ConfigMap that will hold the trusted CA"
+          k8s:
+            state: present
+            definition: "{{ lookup('template', 'configmap-trusted-ca.yml.j2') }}"
+
   - when:
       - feature_auth_required|bool
       - feature_auth_provider == "keycloak"

--- a/roles/tackle/templates/configmap-trusted-ca.yml.j2
+++ b/roles/tackle/templates/configmap-trusted-ca.yml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  namespace: {{ app_namespace }}
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+    app.kubernetes.io/part-of: {{ app_name }}

--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -120,7 +120,18 @@ spec:
             - name: {{ ui_tls_secret_name }}
               mountPath: /var/run/secrets/{{ ui_tls_secret_name }}/tls.crt
 {% endif %}
+{% if trusted_ca_enabled is defined and trusted_ca_enabled|bool %}
+            - name: trusted-ca
+              mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
+{% endif %}
       volumes:
+{% if ui_tls_enabled|bool %}
+        - name: {{ ui_tls_secret_name }}
+          secret:
+            secretName: {{ ui_tls_secret_name }}
+            defaultMode: 420
+{% endif %}
 {% if trusted_ca_enabled is defined and trusted_ca_enabled|bool %}
         - name: trusted-ca
           configMap:
@@ -128,10 +139,4 @@ spec:
             items:
               - key: ca-bundle.crt
                 path: tls-ca-bundle.pem
-{% endif %}
-{% if ui_tls_enabled|bool %}
-        - name: {{ ui_tls_secret_name }}
-          secret:
-            secretName: {{ ui_tls_secret_name }}
-            defaultMode: 420
 {% endif %}

--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -62,6 +62,8 @@ spec:
             - name: KEYCLOAK_CLIENT_ID
               value: {{ ui_service_name }}
 {% endif %}
+            - name: NODE_EXTRA_CA_CERTS
+              value: {{ ui_node_extra_ca_certs }}
 {% if ui_tls_enabled|bool %}
             - name: UI_TLS_ENABLED
               value: 'true'
@@ -113,11 +115,21 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-{% if ui_tls_enabled|bool %}
           volumeMounts:
+{% if ui_tls_enabled|bool %}
             - name: {{ ui_tls_secret_name }}
               mountPath: /var/run/secrets/{{ ui_tls_secret_name }}/tls.crt
+{% endif %}
       volumes:
+{% if trusted_ca_enabled is defined and trusted_ca_enabled|bool %}
+        - name: trusted-ca
+          configMap:
+            name: trusted-ca
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem
+{% endif %}
+{% if ui_tls_enabled|bool %}
         - name: {{ ui_tls_secret_name }}
           secret:
             secretName: {{ ui_tls_secret_name }}


### PR DESCRIPTION
PR Summary:

- Add NODE_EXTRA_CA_CERTS environment var to UI deployment pod for nodejs consumption of CA bundle
- Add support for custom ingress CA certificates if they are present in OpenShift
- Related to https://github.com/konveyor/tackle2-ui/pull/447
- Target 2.1.2 release

Signed-off-by: Franco Bladilo <fbladilo@redhat.com>