### PR TITLE
Windup addon ensure image pull policy is set

### DIFF
--- a/roles/tackle/templates/customresource-addon-windup.yml.j2
+++ b/roles/tackle/templates/customresource-addon-windup.yml.j2
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/part-of: {{ app_name }}
 spec:
   image: {{ windup_fqin }}
+  imagePullPolicy: {{ image_pull_policy }}
   resources:
     requests:
       cpu: {{ windup_container_requests_cpu }}


### PR DESCRIPTION
The windup addon image pull policy is now controlled by the global image_pull_policy parameter in the Tackle CR. 

This addresses possible inconsistencies between the windup addon pull policy and the rest of Tackle components.

Signed-off-by: Franco Bladilo <fbladilo@redhat.com>