### PR TITLE
Ensure windup addon is always reconciled

### DIFF
--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -337,19 +337,10 @@
     name: "{{ admin_name }}"
     namespace: "{{ app_namespace }}"
 
-- name: "Check if Windup Addon CR exists already so we don't update it"
-  k8s_info:
-    api_version: tackle.konveyor.io/v1alpha1
-    kind: Addon
-    name: "{{ windup_name }}"
-    namespace: "{{ app_namespace }}"
-  register: windup_cr_status
-
 - name: "Create Windup Addon CR"
   k8s:
     state: present
     definition: "{{ lookup('template', 'customresource-addon-windup.yml.j2') }}"
-  when: (windup_cr_status.resources | length) == 0
 
 - name: "Create Network Policy"
   k8s:


### PR DESCRIPTION
Signed-off-by: Franco Bladilo <fbladilo@redhat.com>

The windup addon (or any other addon for this matter), should always be reconciled to avoid stale data , such as a old addon image reference or to also honor Tackle CR settings such as image pull policy or resource requests.

This is specially impactful during Tackle upgrades, see : https://issues.redhat.com/browse/MTA-127

This PR removes the set and forget task by operator and forces to reconcile in every cycle. 
