### PR TITLE
:bug: Manage DB container for RHSSO

### DIFF
--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -300,6 +300,13 @@ spec:
       - serviceAccountName: tackle-operator
         rules:
         - apiGroups:
+          - operator.openshift.io
+          resources:
+          - dnses
+          verbs:
+          - list
+          - get
+        - apiGroups:
           - config.openshift.io
           resources:
           - clusterversions

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -42,7 +42,6 @@
 
 - when:
     - feature_auth_required|bool
-    - app_profile == "konveyor"
   block:
     - name: "Setup Keycloak PostgreSQL PersistentVolumeClaim"
       k8s:
@@ -91,7 +90,7 @@
         namespace: "{{ app_namespace }}"
         label_selectors:
           - app.kubernetes.io/name = {{ keycloak_database_service_name }}
-        wait: yes
+        wait: true
         wait_condition:
           type: "Ready"
           status: "True"
@@ -120,33 +119,87 @@
             state: present
             definition: "{{ lookup('template', 'secret-keycloak-sso.yml.j2') }}"
 
-    - name: "Setup Keycloak SSO Service"
-      k8s:
-        state: present
-        definition: "{{ lookup('template', 'service-keycloak-sso.yml.j2') }}"
+    - when:
+        - app_profile == "konveyor"
+      block:
+        - name: "Setup Keycloak SSO Service"
+          k8s:
+            state: present
+            definition: "{{ lookup('template', 'service-keycloak-sso.yml.j2') }}"
 
-    - name: "Setup Keycloak SSO Deployment"
-      k8s:
-        state: present
-        definition: "{{ lookup('template', 'deployment-keycloak-sso.yml.j2') }}"
+        - name: "Setup Keycloak SSO Deployment"
+          k8s:
+            state: present
+            definition: "{{ lookup('template', 'deployment-keycloak-sso.yml.j2') }}"
+
 - when:
     - feature_auth_required|bool
     - app_profile == "mta"
   block:
-    - name: "Check if RHSSO Keycloak CR exists already so we don't update it"
+    - name: "Check for existing RHSSO Keycloak CR"
       k8s_info:
         api_version: "{{ rhsso_api_version }}"
         kind: Keycloak
         namespace: "{{ app_namespace }}"
         label_selectors:
           - app = {{ rhsso_service_name }}
-      register: rhsso_keycloak_status
+      register: rhsso_keycloak
+
+    - name: "Delete old RHSSO Keycloak"
+      k8s:
+        state: absent
+        api_version: "{{ rhsso_api_version }}"
+        kind: Keycloak
+        name: "{{ rhsso_service_name }}"
+        namespace: "{{ app_namespace }}"
+      when:
+        - rhsso_keycloak.resources | length > 0
+        - '"keycloak-postgresql" in rhsso_keycloak.resources[0].status.secondaryResources.Deployment'
+
+    - name: "Get PostgreSQL Keycloak Secret"
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ keycloak_database_secret_name }}"
+        namespace: "{{ app_namespace }}"
+      register: keycloak_database_secret
+
+    - name: "Get DNS operator CR"
+      k8s_info:
+        api_version: operator.openshift.io/v1
+        kind: DNS
+        name: default
+      register: default_dns_operator
+
+    - name: "Collect service name components"
+      set_fact:
+        pgsql_svc_fqdn_parts:
+          - "{{ keycloak_database_service_name }}"
+          - "{{ app_namespace }}"
+          - "svc"
+          - "{{ default_dns_operator.resources[0].status.clusterDomain }}"
+
+    - name: "Assemble service name"
+      set_fact:
+        pgsql_svc_fqdn: "{{ pgsql_svc_fqdn_parts | join('.') }}"
+
+    - name: "Collect database coordinates"
+      set_fact:
+        rhsso_db_pass_b64: "{{ keycloak_database_secret.resources[0].data['database-password'] }}"
+        rhsso_db_user_b64: "{{ keycloak_database_secret.resources[0].data['database-user'] }}"
+        rhsso_db_host_b64: "{{ pgsql_svc_fqdn | b64encode }}"
+        rhsso_db_name_b64: "{{ keycloak_database_secret.resources[0].data['database-name'] }}"
+
+    - name: "Setup Keycloak SSO Deployment"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'secret-keycloak-db.yml.j2') }}"
+        merge_type: merge
 
     - name: "Create RHSSO Keycloak CR"
       k8s:
         state: present
         definition: "{{ lookup('template', 'customresource-rhsso-keycloak.yml.j2') }}"
-      when: (rhsso_keycloak_status.resources | length) == 0
 
     - name: "Check RHSSO for readiness"
       k8s_info:
@@ -207,7 +260,7 @@
     namespace: "{{ app_namespace }}"
     label_selectors:
       - app.kubernetes.io/name = {{ pathfinder_database_service_name }}
-    wait: yes
+    wait: true
     wait_condition:
       type: "Ready"
       status: "True"
@@ -281,6 +334,15 @@
       k8s:
         state: present
         definition: "{{ lookup('template', 'secret-hub.yml.j2') }}"
+
+
+- name: "Look up Keycloak DB Secret for Hashing"
+  set_fact:
+    keycloak_db_secret:
+      env: "{{ lookup('template', 'secret-keycloak-db.yml.j2') | from_yaml }}"
+  when:
+    - feature_auth_required|bool
+    - app_profile == "mta"
 
 - name: "Setup Hub API Service"
   k8s:

--- a/roles/tackle/templates/customresource-rhsso-keycloak.yml.j2
+++ b/roles/tackle/templates/customresource-rhsso-keycloak.yml.j2
@@ -8,5 +8,7 @@ metadata:
     app: {{ rhsso_service_name }}
 spec:
   instances: 1
+  externalDatabase:
+    enabled: true
   externalAccess:
     enabled: {{ rhsso_external_access }}

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -39,6 +39,11 @@ spec:
         app.kubernetes.io/part-of: {{ app_name }}
         app: {{ app_name }}
         role: {{ hub_service_name }}
+{% if feature_auth_required|bool %}
+{% if app_profile == 'mta' %}
+        keycloak_db_secret_name: {{ keycloak_db_secret.env | k8s_config_resource_name }}
+{% endif %}
+{% endif %}
     spec:
       serviceAccountName: {{ hub_serviceaccount_name }}
       containers:

--- a/roles/tackle/templates/secret-keycloak-db.yml.j2
+++ b/roles/tackle/templates/secret-keycloak-db.yml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  POSTGRES_DATABASE: {{ rhsso_db_name_b64 }} 
+  POSTGRES_EXTERNAL_ADDRESS: {{ rhsso_db_host_b64 }}
+  POSTGRES_HOST:
+  POSTGRES_PASSWORD: {{ rhsso_db_pass_b64 }}
+  POSTGRES_USERNAME: {{ rhsso_db_user_b64 }}
+  POSTGRES_SUPERUSER: {{ "true" | b64encode }}
+  SSLMODE: {{ "prefer" | b64encode }}
+kind: Secret
+metadata:
+  labels:
+    app: keycloak
+    app.kubernetes.io/name: {{ keycloak_sso_service_name }}
+    app.kubernetes.io/component: {{ keycloak_sso_component_name }}
+    app.kubernetes.io/part-of: {{ app_name }}
+  name: keycloak-db-secret
+  namespace: {{ app_namespace }}
+type: Opaque


### PR DESCRIPTION
These changes are intended to switch us from using a postgresql container provisioned by the RHSSO operator which is unsupported and uses a tag making it impossible to use MTA in a disconnected cluster (without enabling an experimental feature to allow mirroring with tags).

The operator will cleanly switch the operator to use a postgresql database container provisioned by us, but it will not migrate data. Users will be required to log back with the default password and reconfigure any users they have created.

~~Up to this point as far as I can tell RHSSO does not appear to deprovision its postgresql deployment when the configuration is changed to use an 'external' database and the keycloak-discovery service never becomes ready, so for an upgrade these manual steps are currently required. I'm still looking to see if we can smooth this out and have some ideas. For example, we can probably look at the mta-rhsso keycloak resource status for the keycloak-postgresql deployment and if it exists nuke it and recreate it, which should clean up keycloak and reprovision it properly.~~
  
~~oc delete keycloak -n openshift-mta mta-rhsso --ignore-not-found=true && \
oc scale deployment -n openshift-mta mta-operator --replicas=0 && \
oc scale deployment -n openshift-mta mta-operator --replicas=1~~
