### PR TITLE
:sparkles: Provide openshift-oauth as an authentication option

### DIFF
--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -144,6 +144,8 @@ spec:
                   value: konveyor
                 - name: VERSION
                   value: 99.0.0
+                - name: RELATED_IMAGE_OAUTH_PROXY
+                  value: docker.io/openshift/oauth-proxy:latest
                 - name: RELATED_IMAGE_TACKLE_HUB
                   value: quay.io/konveyor/tackle2-hub:latest
                 - name: RELATED_IMAGE_PATHFINDER_DATABASE
@@ -200,6 +202,7 @@ spec:
           - events
           - configmaps
           - secrets
+          - serviceaccounts
           verbs:
           - '*'
         - apiGroups:
@@ -328,6 +331,8 @@ spec:
           - update
           - patch
           - delete
+      - serviceAccountName: tackle-ui
+        rules: []
   installModes:
   - supported: true
     type: OwnNamespace

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -7,6 +7,7 @@ app_version: "{{ lookup('env', 'VERSION') }}"
 
 # Feature defaults
 feature_auth_required: "{{ false if app_profile == 'konveyor' else true }}"
+feature_auth_type: keycloak
 feature_isolate_namespace: true
 
 # Environment
@@ -135,6 +136,7 @@ keycloak_sso_url: "{{ keycloak_sso_proto }}://{{ keycloak_sso_service_name }}.{{
 ui_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_TACKLE_UI') }}"
 ui_component_name: "ui"
 ui_service_name: "{{ app_name }}-{{ ui_component_name }}"
+ui_serviceaccount_name: "{{ app_name }}-{{ ui_component_name }}"
 ui_configmap_name: "{{ ui_service_name }}-config"
 ui_deployment_name: "{{ ui_service_name }}"
 ui_deployment_replicas: "1"
@@ -153,6 +155,12 @@ ui_proto: "{{ 'https' if ui_tls_enabled | bool else 'http' }}"
 ui_node_extra_ca_certs: "/opt/app-root/src/ca.crt"
 ui_route_tls_termination: "edge"
 ui_route_tls_insecure_termination_policy: "Redirect"
+
+oauth_provider: openshift
+oauth_default_openshift_sar: --openshift-sar={"namespace":"{{ app_namespace }}","resource":"services","resourceName":"{{ ui_service_name }}","verb":"get"}
+oauth_access_rule: "{{ oauth_default_openshift_sar if oauth_provider == 'openshift' }}"
+oauth_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_OAUTH_PROXY') }}"
+oauth_ssl_port: 9443
 
 admin_fqin: "{{ lookup('env', 'RELATED_IMAGE_ADDON_ADMIN') }}"
 admin_name: "admin"

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -42,6 +42,56 @@
 
 - when:
     - feature_auth_required|bool
+    - feature_auth_type == "oauth"
+  block:
+    - name: "Check if Cookie Secret already exists"
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        name: cookie-secret
+        namespace: "{{ app_namespace }}"
+      register: cookie_secret
+
+    - name: "Generate Cookie Secret"
+      set_fact:
+        new_cookie_secret: "{{ lookup('password', '/dev/null chars=ascii_lowercase,ascii_uppercase,digits length=32') }}"
+      when: (cookie_secret.resources | length) == 0
+
+    - name: "Create Cookie Secret"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'secret-cookie-secret.yml.j2') }}"
+      when: (cookie_secret.resources | length) == 0
+
+    - name: "Retrieve Cookie Secret"
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        name: cookie-secret
+        namespace: "{{ app_namespace }}"
+      register: cookie_secret
+
+    - name: "Set Cookie Secret"
+      set_fact:
+        cookie_secret_data: "{{ cookie_secret.resources[0].data['cookie-secret'] | b64decode }}"
+
+    - name: "Retrieve Oauth Client Secret if it exists"
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        name: oauth-client-secret
+        namespace: "{{ app_namespace }}"
+      register: oauth_client_secret_status
+
+    - name: "Set Oauth Client Secret"
+      set_fact:
+        oauth_client_secret: "{{ oauth_client_secret_status.resources[0].data['client-secret'] | b64decode }}"
+      when: (oauth_client_secret_status.resources | length) > 0
+
+- when:
+    - feature_auth_required|bool
+    - feature_auth_type == "keycloak"
+    - app_profile == "konveyor"
   block:
     - name: "Setup Keycloak PostgreSQL PersistentVolumeClaim"
       k8s:
@@ -134,6 +184,7 @@
 
 - when:
     - feature_auth_required|bool
+    - feature_auth_type == "keycloak"
     - app_profile == "mta"
   block:
     - name: "Check for existing RHSSO Keycloak CR"
@@ -356,6 +407,11 @@
     definition: "{{ lookup('template', 'deployment-hub.yml.j2') }}"
     merge_type: merge
 
+- name: "Setup UI ServiceAccount"
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'serviceaccount-ui.yml.j2') }}"
+
 - name: "Setup UI Service"
   k8s:
     state: present
@@ -365,6 +421,7 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'deployment-ui.yml.j2') }}"
+    merge_type: merge
 
 - name: "Setup UI Ingress"
   k8s:
@@ -410,3 +467,30 @@
     state: present
     definition: "{{ lookup('template', 'networkpolicy.yml.j2') }}"
   when: feature_isolate_namespace|bool
+
+- when:
+    - not(feature_auth_required|bool) or not(feature_auth_type == "keycloak")
+  block:
+    - name: "Deprovision RHSSO Keycloak CR"
+      k8s:
+        state: absent
+        kind: Keycloak
+        api_version: "{{ rhsso_api_version }}"
+        name: "{{ rhsso_service_name }}"
+        namespace: "{{ app_namespace }}"
+
+    - name: "Deprovision RHSSO Keycloak Deployment"
+      k8s:
+        state: absent
+        kind: Deployment
+        api_version: apps/v1
+        name: "{{ keycloak_database_deployment_name }}"
+        namespace: "{{ app_namespace }}"
+
+    - name: "Deprovision RHSSO Keycloak Postgres"
+      k8s:
+        state: absent
+        kind: Deployment
+        api_version: apps/v1
+        name: "{{ keycloak_sso_deployment_name }}"
+        namespace: "{{ app_namespace }}"

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -11,7 +11,7 @@ metadata:
   annotations:
     app.openshift.io/connects-to: >-
       [
-{% if feature_auth_required|bool %}
+{% if feature_auth_required|bool and feature_auth_type == "keycloak" %}
 {% if app_profile == 'konveyor' %}
         { "apiVersion": "apps/v1", "kind": "Deployment", "name": "{{ keycloak_sso_deployment_name }}" },
 {% elif app_profile == 'mta' %}
@@ -97,11 +97,16 @@ spec:
                 secretKeyRef:
                   name: "{{ hub_secret_name }}"
                   key: addon_token
+{% if feature_auth_required|bool and feature_auth_type == "keycloak" %}
             - name: AUTH_REQUIRED
-              value: '{{ feature_auth_required|lower }}'
+              value: "true"
+{% else %}
+            - name: AUTH_REQUIRED
+              value: "false"
+{% endif %}
             - name: PATHFINDER_URL
               value: "{{ pathfinder_url }}"
-{% if feature_auth_required|bool %}
+{% if feature_auth_required|bool and feature_auth_type == "keycloak" %}
             - name: KEYCLOAK_REALM
               value: "{{ keycloak_sso_realm }}"
             - name: KEYCLOAK_CLIENT_ID

--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -11,12 +11,10 @@ metadata:
   annotations:
     app.openshift.io/connects-to: >-
       [
-{% if feature_auth_required|bool %}
-{% if app_profile == 'konveyor' %}
+{% if feature_auth_required|bool and feature_auth_type == "keycloak" and app_profile == 'konveyor' %}
         { "apiVersion": "apps/v1", "kind": "Deployment", "name": "{{ keycloak_sso_deployment_name }}" },
-{% elif app_profile == 'mta' %}
+{% elif feature_auth_required|bool and feature_auth_type == "keycloak" and app_profile == 'mta' %}
         { "apiVersion": "apps/v1", "kind": "StatefulSet", "name": "keycloak" },
-{% endif %}
 {% endif %}
         { "apiVersion": "apps/v1", "kind": "Deployment", "name": "{{ hub_deployment_name }}" }
       ]
@@ -37,6 +35,51 @@ spec:
         role: {{ ui_service_name }}
     spec:
       containers:
+{% if feature_auth_required|bool and feature_auth_type == "oauth" %}
+        - args:
+          - --https-address=:{{ oauth_ssl_port }}
+          - --provider={{ oauth_provider }}
+          - --upstream=http://localhost:{{ ui_port }}
+          - --cookie-secret={{ cookie_secret_data }}
+{% if oauth_provider == "openshift" %}
+          - --openshift-service-account={{ ui_serviceaccount_name }}
+          - --tls-cert=/etc/tls/private/tls.crt
+          - --tls-key=/etc/tls/private/tls.key
+{% else %}
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-key-file=/etc/tls/private/tls.key
+{% if oauth_email_domain is defined %}
+          - --email-domain={{ oauth_email_domain }}
+{% endif %}
+{% if oauth_client_id is defined %}
+          - --client-id={{ oauth_client_id }}
+{% endif %}
+{% if oauth_client_secret is defined %}
+          - --client-secret={{ oauth_client_secret }}
+{% endif %}
+{% endif %}
+{% if oauth_access_rule != "" %}
+          - {{ oauth_access_rule }}
+{% endif %}
+{% if oauth_extra_opts is defined %}
+{% for item in oauth_extra_opts  %}
+          - {{ item }}
+{% endfor %}
+{% endif %}
+          image: "{{ oauth_image_fqin }}"
+          imagePullPolicy: "{{ image_pull_policy }}"
+          name: oauth-proxy
+          ports:
+          - containerPort: 8081
+            name: public
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: {{ ui_tls_secret_name }}
+{% endif %}
         - name: {{ ui_container_name }}
           image: "{{ ui_image_fqin }}"
           imagePullPolicy: "{{ image_pull_policy }}"
@@ -51,9 +94,9 @@ spec:
               value: '{{ui_ingress_proxy_body_size}}'
             - name: TACKLE_HUB_URL
               value: "{{ hub_url }}"
+{% if feature_auth_required|bool and feature_auth_type == "keycloak" %}
             - name: AUTH_REQUIRED
-              value: "{{ feature_auth_required|lower }}"
-{% if feature_auth_required|bool %}
+              value: "true"
             - name: KEYCLOAK_REALM
               value: {{ keycloak_sso_realm }}
             - name: KEYCLOAK_CLIENT_ID
@@ -65,6 +108,9 @@ spec:
             - name: KEYCLOAK_SERVER_URL
               value: {{ keycloak_sso_url }}
 {% endif %}
+{% else %}
+            - name: AUTH_REQUIRED
+              value: "false"
 {% endif %}
             - name: NODE_EXTRA_CA_CERTS
               value: {{ ui_node_extra_ca_certs }}
@@ -122,8 +168,9 @@ spec:
               mountPath: /etc/pki/ca-trust/extracted/pem
               readOnly: true
 {% endif %}
+      serviceAccount: {{ ui_serviceaccount_name }}
       volumes:
-{% if ui_tls_enabled|bool %}
+{% if ui_tls_enabled|bool or (feature_auth_required|bool and feature_auth_type == "oauth") %}
         - name: {{ ui_tls_secret_name }}
           secret:
             secretName: {{ ui_tls_secret_name }}

--- a/roles/tackle/templates/route-ui.yml.j2
+++ b/roles/tackle/templates/route-ui.yml.j2
@@ -16,5 +16,9 @@ spec:
     kind: Service
     name: {{ ui_service_name }}
   tls:
+{% if feature_auth_required|bool and feature_auth_type == "oauth" %}
+    termination: reencrypt
+{% else %}
     termination: {{ ui_route_tls_termination }}
+{% endif %}
     insecureEdgeTerminationPolicy: {{ ui_route_tls_insecure_termination_policy }}

--- a/roles/tackle/templates/secret-cookie-secret.yml.j2
+++ b/roles/tackle/templates/secret-cookie-secret.yml.j2
@@ -1,0 +1,12 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ keycloak_sso_service_name }}
+    app.kubernetes.io/component: {{ keycloak_sso_component_name }}
+    app.kubernetes.io/part-of: {{ app_name }}
+  name: cookie-secret
+  namespace: {{ app_namespace }}
+type: Opaque
+data:
+  cookie-secret: {{ new_cookie_secret | b64encode }}

--- a/roles/tackle/templates/service-ui.yml.j2
+++ b/roles/tackle/templates/service-ui.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-{% if ui_tls_enabled|bool and openshift_cluster|bool %}
+{% if (ui_tls_enabled|bool and openshift_cluster|bool) or (feature_auth_required|bool and feature_auth_type == "oauth") %}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ ui_tls_secret_name }}
 {% endif %}
@@ -14,10 +14,17 @@ metadata:
   namespace: {{ app_namespace }}
 spec:
   ports:
+{% if feature_auth_required|bool and feature_auth_type == "oauth" %}
+    - name: ui
+      port: {{ oauth_ssl_port }}
+      targetPort: {{ oauth_ssl_port }}
+      protocol: TCP
+{% else %}
     - name: ui
       port: {{ ui_port }}
       targetPort: {{ ui_port }}
       protocol: TCP
+{% endif %}
   selector:
     app.kubernetes.io/name: {{ ui_service_name }}
     app.kubernetes.io/component: {{ ui_component_name }}

--- a/roles/tackle/templates/serviceaccount-ui.yml.j2
+++ b/roles/tackle/templates/serviceaccount-ui.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ ui_serviceaccount_name }}
+  namespace: {{ app_namespace }}
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"{{ ui_route_name }}"}}'


### PR DESCRIPTION
WIP. Need to test downstream and turning auth on and off and switching a little more.

Right now I've switched from keycloak -> oauth without issue.

Could use clean up around conditionals in templates as well. These should be possible to make smaller and cleaner.