### PR TITLE
:bug: Fix keycloak deployment check (#162)

### DIFF
--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -154,6 +154,7 @@
         namespace: "{{ app_namespace }}"
       when:
         - rhsso_keycloak.resources | length > 0
+        - rhsso_keycloak.resources[0].status.secondaryResources.Deployment is defined
         - '"keycloak-postgresql" in rhsso_keycloak.resources[0].status.secondaryResources.Deployment'
 
     - name: "Get PostgreSQL Keycloak Secret"


### PR DESCRIPTION
When not coming from an upgrade situation the Deployment array in secondary resources doesn't exist and it causes a reconcile failure.