### PR TITLE
:bug: Don't set an empty storageClassName when not set

### DIFF
--- a/roles/tackle/templates/persistentvolumeclaim-cache.yml.j2
+++ b/roles/tackle/templates/persistentvolumeclaim-cache.yml.j2
@@ -17,7 +17,5 @@ spec:
 {% if cache_storage_class is defined %}
 {% if cache_storage_class|length %}
   storageClassName: {{ cache_storage_class }}
-{% else %}
-  storageClassName: ""
 {% endif %}
 {% endif %}

--- a/roles/tackle/templates/persistentvolumeclaim-hub-bucket.yml.j2
+++ b/roles/tackle/templates/persistentvolumeclaim-hub-bucket.yml.j2
@@ -18,7 +18,5 @@ spec:
 {% if hub_bucket_storage_class is defined %}
 {% if hub_bucket_storage_class|length %}
   storageClassName: {{ hub_bucket_storage_class }}
-{% else %}
-  storageClassName: ""
 {% endif %}
 {% endif %}

--- a/roles/tackle/templates/persistentvolumeclaim-hub-database.yml.j2
+++ b/roles/tackle/templates/persistentvolumeclaim-hub-database.yml.j2
@@ -18,7 +18,5 @@ spec:
 {% if rwo_storage_class is defined %}
 {% if rwo_storage_class|length %}
   storageClassName: {{ rwo_storage_class }}
-{% else %}
-  storageClassName: ""
 {% endif %}
 {% endif %}

--- a/roles/tackle/templates/persistentvolumeclaim-keycloak-postgresql.yml.j2
+++ b/roles/tackle/templates/persistentvolumeclaim-keycloak-postgresql.yml.j2
@@ -18,7 +18,5 @@ spec:
 {% if rwo_storage_class is defined %}
 {% if rwo_storage_class|length %}
   storageClassName: {{ rwo_storage_class }}
-{% else %}
-  storageClassName: ""
 {% endif %}
 {% endif %}

--- a/roles/tackle/templates/persistentvolumeclaim-pathfinder-postgresql.yml.j2
+++ b/roles/tackle/templates/persistentvolumeclaim-pathfinder-postgresql.yml.j2
@@ -18,7 +18,5 @@ spec:
 {% if rwo_storage_class is defined %}
 {% if rwo_storage_class|length %}
   storageClassName: {{ rwo_storage_class }}
-{% else %}
-  storageClassName: ""
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Setting an empty storageClassName can result in failure for the default storage class provisioner to provision the PVC.

This was observed on a GCP cluster @rayfordj was test on.

```
$ oc describe pvc mta-hub-bucket-volume-claim
Name:          mta-hub-bucket-volume-claim
Namespace:     openshift-mta
StorageClass:  
Status:        Pending
Volume:        
Labels:        app.kubernetes.io/component=hub
               app.kubernetes.io/name=mta-hub
               app.kubernetes.io/part-of=mta
               volume=mta-hub-bucket
Annotations:   <none>
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       mta-hub-96dc6ff9d-cbn5k
Events:
  Type    Reason         Age                  From                         Message
  ----    ------         ----                 ----                         -------
  Normal  FailedBinding  12s (x17 over 4m3s)  persistentvolume-controller  no persistent volumes available for this claim and no storage class is set
```