### PR TITLE
:bug: Update memory limit for minikube start command in the documentation

### DIFF
--- a/docs/installation-macos.md
+++ b/docs/installation-macos.md
@@ -12,7 +12,7 @@ podman machine set --rootful
 podman machine start
 ```
 2. Create a Minikube cluster with podman as the driver option
-`minikube start --memory=10g --driver podman`
+`minikube start --memory=9g --driver podman`
 3. Install ingress addon
 `minikube addons enable ingress`
 4. Install OLM to manage Tackle operator


### PR DESCRIPTION
Following the install guide as-is throws an error while starting minikube. To solve the error, this PR adjusts the memory limit for minikube to be a little less than podman.