### PR TITLE
:sparkles: Make feature_auth_required false by default

### DIFF
--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
             "namespace": "konveyor-tackle"
           },
           "spec": {
-            "feature_auth_required": "true"
+            "feature_auth_required": "false"
           }
         },
         {
@@ -48,7 +48,7 @@ metadata:
           "namespace": "konveyor-tackle"
         },
         "spec": {
-          "feature_auth_required": "true"
+          "feature_auth_required": "false"
         }
       }
     operatorframework.io/suggested-namespace: konveyor-tackle

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -6,7 +6,7 @@ app_profile: "{{ lookup('env', 'PROFILE') }}"
 app_version: "{{ lookup('env', 'VERSION') }}"
 
 # Feature defaults
-feature_auth_required: true
+feature_auth_required: "{{ false if app_profile == 'konveyor' else true }}"
 feature_isolate_namespace: true
 
 # Environment


### PR DESCRIPTION
Requested that konveyor not require auth by default.