### PR TITLE
:bug: Set fsGroup for non-OpenShift clusters

### DIFF
--- a/roles/tackle/templates/deployment-keycloak-postgresql.yml.j2
+++ b/roles/tackle/templates/deployment-keycloak-postgresql.yml.j2
@@ -85,6 +85,10 @@ spec:
             failureThreshold: 3
           terminationMessagePath: "/dev/termination-log"
           terminationMessagePolicy: File
+{% if not openshift_cluster %}
+      securityContext:
+        fsGroup: 26
+{% endif %}
       volumes:
         - name: {{ keycloak_database_data_volume_name }}
           persistentVolumeClaim:

--- a/roles/tackle/templates/deployment-pathfinder-postgresql.yml.j2
+++ b/roles/tackle/templates/deployment-pathfinder-postgresql.yml.j2
@@ -83,6 +83,10 @@ spec:
           volumeMounts:
             - name: {{ pathfinder_database_data_volume_name }}
               mountPath: {{ pathfinder_database_data_volume_path }}
+{% if not openshift_cluster %}
+      securityContext:
+        fsGroup: 26
+{% endif %}
       volumes:
         - name: {{ pathfinder_database_data_volume_name }}
           persistentVolumeClaim:


### PR DESCRIPTION
On EKS and probably other kubernetes variants the PostgreSQL pods run as user 26. Without setting the fsGroup the storage is mounted 755 owned by root:root so postgres can't write and fails to start with a permission denied.

26 comes from the Dockerfile the image is built with https://github.com/sclorg/postgresql-container/blob/master/12/Dockerfile.centos7#L88