### PR TITLE
:seedling: create-release workflow should pass token

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,6 +24,9 @@ jobs:
           - konveyor/tackle2-hub
     uses: konveyor/release-tools/.github/workflows/create-release.yml@main
     with:
+      version: ${{ github.event.inputs.version }}
       repository: ${{ matrix.repository }}
       ref: ${{ github.event.inputs.branch }}
+    secrets:
+      token: ${{ secrets.GH_TOKEN }}
       # TODO(djzager) Next we'll need to force the multi-arch build steps to run


### PR DESCRIPTION
We can't use GitHub's automatic token if 1) we want to create releases in other repositories (ie. operator creating a release in the hub) and 2) we want the publish steps to run in those repos.