### PR TITLE
:seedling: Updated for konveyor-operator name change for dev workflow

### DIFF
--- a/tackle-k8s-dev.yaml
+++ b/tackle-k8s-dev.yaml
@@ -16,6 +16,6 @@ metadata:
 spec:
   channel: development
   installPlanApproval: Automatic
-  name: tackle-operator
+  name: konveyor-operator
   source: konveyor-tackle
   sourceNamespace: konveyor-tackle


### PR DESCRIPTION
The [tools/tackle-opdev.sh](https://github.com/konveyor/tackle2-operator/blob/main/tools/tackle-opdev.sh#L155) script uses this for dev workflows

I think this needs to updated for the konveyor-operator rename.
