### PR TITLE
:seedling: Updates to build on mac arm64 and deploy to amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ VERSION ?= 99.0.0
 # with docker or podman
 CONTAINER_RUNTIME ?= docker
 
+# TARGET_ARCH is the architecture of the image to be built
+# Note, that even developers running on arm64 Macs will likely want to set
+# this to amd64 when building local images to deploy into remote clusters
+TARGET_ARCH ?= amd64
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -82,7 +87,7 @@ run: ansible-operator ## Run against the configured Kubernetes cluster in ~/.kub
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_RUNTIME) build -t ${IMG} .
+	$(CONTAINER_RUNTIME) build --arch ${TARGET_ARCH} -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -151,7 +156,7 @@ bundle: kustomize ## Generate bundle manifests and metadata, then validate gener
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	$(CONTAINER_RUNTIME) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_RUNTIME) build --arch ${TARGET_ARCH} -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/tools/tackle-opdev.sh
+++ b/tools/tackle-opdev.sh
@@ -15,6 +15,7 @@ PROJECT_NS="konveyor-tackle"
 TAG="latest"
 NAME="Tackle"
 
+
 function usage () {
 echo
 echo "Valid arguments for $(basename $0):"
@@ -118,7 +119,15 @@ if [ ! -z ${RUN_BUNDLE} ]; then
 	echo "##### Building and pushing Bundle #####"
 	echo
 	# Must patch bundle CSV with target custom operator image first, assumes main branch latest tag
-	sed -i "s/quay.io\/konveyor\/tackle2-operator:latest/quay.io\/${QUAY_NS}\/tackle2-operator:${TAG}/" ${CSV_PATH}
+    BODY="s|quay.io/konveyor/tackle2-operator:latest|quay.io/${QUAY_NS}/tackle2-operator:${TAG}|" 
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # sed on MacOS requires an argument for -i to optionally be an extension for the backup file
+        # we are giving it '' to avoid creating a backup file
+        # https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+        sed -i '' ${BODY} ${CSV_PATH}
+    else
+        sed -i ${BODY} ${CSV_PATH}
+    fi
 	operator-sdk bundle validate ./bundle && make bundle-build bundle-push BUNDLE_IMG=quay.io/${QUAY_NS}/${BUNDLE_REPO}:${TAG}
 fi
 


### PR DESCRIPTION
With these changes I'm able to locally build on my arm64 Mac and deploy the images onto my EKS cluster (amd64).

Needed to address 2 issues:

1. Allow --arch amd64 to be passed into image builds in Makefile
2. Account for "sed -i" difference on Mac vs Linux
