### PR TITLE
:sparkles: Update CSV to support installation into multiple namespaces

### DIFF
--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -337,9 +337,9 @@ spec:
   installModes:
   - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
-  - supported: false
+  - supported: true
     type: MultiNamespace
   - supported: false
     type: AllNamespaces


### PR DESCRIPTION
In order to support multi-tenant environments, such as sandbox it will be necessary to be able to install in multiple namespaces.