### PR TITLE
:ghost: Remove the extra nested dir when copying to operatorhub-io

### DIFF
--- a/tools/konveyor-operator-publish-commands.sh
+++ b/tools/konveyor-operator-publish-commands.sh
@@ -192,7 +192,7 @@ echo "   remove scorecard annotations"
 /tmp/yq eval --inplace 'del(.annotations["operators.operatorframework.io.test.config.v1"])' ${CO_OPERATOR_ANNOTATIONS}
 
 echo "   copy updated operator files to K8s repo and submit PR"
-cp -r ${CO_OPERATOR_DIR} ${CO_OPERATOR_DIR_K8S}
+cp -r ${CO_OPERATOR_DIR}/. ${CO_OPERATOR_DIR_K8S}
 pushd "${CO_DIR_K8S}"
 git checkout -B "${OPERATOR_VERSION}"
 git add --all


### PR DESCRIPTION
We're creating an extra nested konveyor-operator directory when copying the operator files for the k8s community operators. https://github.com/k8s-operatorhub/community-operators/pull/2729

I believe this should fix it.