### PR TITLE
:ghost: Make last edit before submitting k8s PR.

### DIFF
--- a/tools/konveyor-operator-publish-commands.sh
+++ b/tools/konveyor-operator-publish-commands.sh
@@ -191,6 +191,9 @@ echo "   remove scorecard annotations"
 /tmp/yq eval --inplace 'del(.annotations["operators.operatorframework.io.test.mediatype.v1"])' ${CO_OPERATOR_ANNOTATIONS}
 /tmp/yq eval --inplace 'del(.annotations["operators.operatorframework.io.test.config.v1"])' ${CO_OPERATOR_ANNOTATIONS}
 
+echo "   add minimum version to annotations"
+/tmp/yq eval --inplace '.annotations["com.redhat.openshift.versions"] = "v4.9" | .annotations["com.redhat.openshift.versions"] style="double"' ${CO_OPERATOR_ANNOTATIONS}
+
 echo "   copy updated operator files to K8s repo and submit PR"
 cp -r ${CO_OPERATOR_DIR}/. ${CO_OPERATOR_DIR_K8S}
 pushd "${CO_DIR_K8S}"
@@ -202,9 +205,6 @@ git push --set-upstream --force origin HEAD
 curl "https://api.github.com/repos/${CO_REPO_K8S}/pulls" --user "${GITHUB_USER}:${GITHUB_TOKEN}" -X POST \
     --data '{"title": "'"$(git log -1 --format=%s)"'", "base": "main", "body": "An automated PR to update konveyor-operator to v'"${OPERATOR_VERSION}"'", "head": "'"${GITHUB_USER}:${OPERATOR_VERSION}"'"}'
 popd
-
-echo "   add minimum version to annotations"
-/tmp/yq eval --inplace '.annotations["com.redhat.openshift.versions"] = "v4.9" | .annotations["com.redhat.openshift.versions"] style="double"' ${CO_OPERATOR_ANNOTATIONS}
 
 echo
 echo "## Submit PR to community operators"


### PR DESCRIPTION
The label being added after  the K8S PR is submitted is not relevant to K8S, but it seems fine for the LABEL to be present in on the operator, as it exists on many others.
https://github.com/search?q=repo%3Ak8s-operatorhub%2Fcommunity-operators%20com.redhat.openshift.versions&type=code

The current flow results in the LABEL being added to the prior version when we submit a new PR, which just looks odd and is probably confusing. Flipping the order should change it to be included on the current version from now on and preventing the strange behavior going forward _after_ the next version is added.