### PR TITLE
:bug: Guard references to Keycloak

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,2 @@
+# This file contains ignores rule violations for ansible-lint
+roles/tackle/tasks/main.yml var-naming[no-role-prefix]

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -161,7 +161,7 @@ ui_route_tls_termination: "edge"
 ui_route_tls_insecure_termination_policy: "Redirect"
 # ui_ingress_path_type should only be defined if you need to override
 # the default value for the ingress controller you are using
-# ui_ingress_path_type: 
+# ui_ingress_path_type:
 
 
 oauth_provider: openshift

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -480,6 +480,10 @@
 - when:
     - not(feature_auth_required|bool) or not(feature_auth_type == "keycloak")
   block:
+    - name: Gather available apis
+      kubernetes.core.k8s_cluster_info:
+      register: tackle_cluster_info
+
     - name: "Deprovision RHSSO Keycloak CR"
       k8s:
         state: absent
@@ -487,6 +491,9 @@
         api_version: "{{ rhsso_api_version }}"
         name: "{{ rhsso_service_name }}"
         namespace: "{{ app_namespace }}"
+      when:
+        - rhsso_api_version in cluster_info.apis
+        - '"Keycloak" in cluster_info.apis[rhsso_api_version]'
 
     - name: "Deprovision RHSSO Keycloak Deployment"
       k8s:


### PR DESCRIPTION
This will prevent the playbook from failing when Keycloak is disabled because it is unable to find the Keycloak kind.

Closes #219

I also added skips for the var-naming role prefix ansible-lint rule as that was failing and is not related to this PR