### PR TITLE
:sparkles: Support for Amazon Load Balancer Ingress controller (#197)

### DIFF
--- a/hack/install-tackle.sh
+++ b/hack/install-tackle.sh
@@ -66,6 +66,7 @@ spec:
   source: konveyor-tackle
   sourceNamespace: konveyor-tackle
 EOF
+# If on MacOS, need to install `brew install coreutils` to get `timeout`
 timeout 600s bash -c 'until kubectl get customresourcedefinitions.apiextensions.k8s.io tackles.tackle.konveyor.io; do sleep 30; done'
 
 # Create, and wait for, tackle

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -146,6 +146,8 @@ ui_container_limits_memory: "800Mi"
 ui_container_requests_cpu: "100m"
 ui_container_requests_memory: "350Mi"
 ui_ingress_name: "{{ app_name }}"
+# Ingress class names of "nginx" and "alb" are expected
+ui_ingress_class_name: "nginx"
 ui_ingress_proxy_body_size: "500m"
 ui_route_name: "{{ app_name }}"
 ui_tls_enabled: false
@@ -155,6 +157,10 @@ ui_proto: "{{ 'https' if ui_tls_enabled | bool else 'http' }}"
 ui_node_extra_ca_certs: "/opt/app-root/src/ca.crt"
 ui_route_tls_termination: "edge"
 ui_route_tls_insecure_termination_policy: "Redirect"
+# ui_ingress_path_type should only be defined if you need to override
+# the default value for the ingress controller you are using
+# ui_ingress_path_type: 
+
 
 admin_fqin: "{{ lookup('env', 'RELATED_IMAGE_ADDON_ADMIN') }}"
 admin_name: "admin"

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -378,6 +378,7 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'ingress-ui.yml.j2') }}"
+    merge_type: merge
   when: not openshift_cluster|bool
 
 - name: "Setup UI Route"

--- a/roles/tackle/templates/ingress-ui.yml.j2
+++ b/roles/tackle/templates/ingress-ui.yml.j2
@@ -3,7 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+{% if ui_ingress_class_name == 'nginx' %}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ ui_ingress_proxy_body_size }}
+{% elif ui_ingress_class_name == 'alb' %}
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/scheme: internet-facing
+{% endif %}
   name: {{ ui_ingress_name }}
   namespace: {{ app_namespace }}
   labels:
@@ -12,14 +17,21 @@ metadata:
     app.kubernetes.io/part-of: {{ app_name }}
     app: {{ app_name }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ ui_ingress_class_name }}
+  
   tls:
     - {}
   rules:
     - http:
         paths:
           - path: /
+{% if ui_ingress_path_type is defined %}
+            pathType: {{ ui_ingress_path_type }}
+{% elif ui_ingress_class_name == 'alb' %}
+            pathType: Prefix
+{% else %}
             pathType: ImplementationSpecific
+{% endif %} 
             backend:
               service:
                 name: {{ ui_service_name }}

--- a/tools/tackle-opdev.sh
+++ b/tools/tackle-opdev.sh
@@ -13,7 +13,7 @@ INDEX_REPO="tackle2-operator-index"
 CATALOG_NS="konveyor-tackle"
 PROJECT_NS="konveyor-tackle"
 TAG="latest"
-NAME="Tackle"
+NAME="Konveyor"
 
 function usage () {
 echo


### PR DESCRIPTION
Fixes #184
Fixes #167 (confirmed working with `feature_auth_required: true`) Relates to #170

These changes allow us to deploy Konveyor onto an Amazon EKS cluster that uses the Amazon recommended Amazon Load Balancer ingress opposed to 'nginx'.

I deployed the EKS cluster for testing using this newly developed automation:
https://github.com/konveyor/hack_env_helpers/tree/main/aws/eks

I captured notes while exploring ALB Ingress here for debugging purposes:
https://gist.github.com/jwmatthews/d492a4944c83dc3f2d016187d53d13b2

---------

Signed-off-by: John Matthews <jwmatthews@gmail.com>
(cherry picked from commit 00792cd545715fa165333714532d3e8ea6d7d04a)