### PR TITLE
:sparkles: Expose Hub metrics (#240)

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -48,6 +48,8 @@ hub_port: "{{ '8443' if hub_tls_enabled | bool else '8080' }}"
 hub_proto: "{{ 'https' if hub_tls_enabled | bool else 'http' }}"
 hub_url: "{{ hub_proto }}://{{ hub_service_name }}.{{ app_namespace }}.svc:{{ hub_port }}"
 hub_log_level: 3
+hub_metrics_enabled: true
+hub_metrics_port: "2112"
 
 pathfinder_database_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_PATHFINDER_DATABASE') }}"
 pathfinder_database_name: "pathfinder"

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -97,6 +97,10 @@ spec:
                 secretKeyRef:
                   name: "{{ hub_secret_name }}"
                   key: addon_token
+            - name: METRICS_ENABLED
+              value: "{{ hub_metrics_enabled }}"
+            - name: METRICS_PORT
+              value: "{{ hub_metrics_port }}"
 {% if feature_auth_required|bool and feature_auth_type == "keycloak" %}
             - name: AUTH_REQUIRED
               value: "true"

--- a/roles/tackle/templates/service-hub.yml.j2
+++ b/roles/tackle/templates/service-hub.yml.j2
@@ -18,6 +18,10 @@ spec:
       port: {{ hub_port }}
       targetPort: {{ hub_port }}
       protocol: TCP
+    - name: metrics
+      port: {{ hub_metrics_port }}
+      targetPort: {{ hub_metrics_port }}
+      protocol: TCP
   selector:
     app.kubernetes.io/name: {{ hub_service_name }}
     app.kubernetes.io/component: {{ hub_component_name }}


### PR DESCRIPTION
This exposes the Hub's prometheus metrics via an additional port on the existing Hub service. This is necessary to properly implement https://issues.redhat.com/projects/MTA/issues/MTA-402.

Related to https://github.com/konveyor/tackle2-hub/pull/335