### PR TITLE
:sparkles: Add ServiceMonitor for hub metrics

### DIFF
--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
     categories: Modernization & Migration
     certified: "false"
     containerImage: quay.io/konveyor/tackle2-operator:latest
-    createdAt: "2023-05-31T20:22:24Z"
+    createdAt: "2023-06-08T20:09:08Z"
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
@@ -283,7 +283,12 @@ spec:
           - servicemonitors
           verbs:
           - get
+          - list
+          - watch
           - create
+          - update
+          - patch
+          - delete
         - apiGroups:
           - apps.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -49,7 +49,12 @@ rules:
   - servicemonitors
   verbs:
   - get
+  - list
+  - watch
   - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - apps.openshift.io
   resources:

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -513,3 +513,11 @@
         api_version: apps/v1
         name: "{{ keycloak_sso_deployment_name }}"
         namespace: "{{ app_namespace }}"
+
+- name: "Create Hub ServiceMonitor"
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'servicemonitor-hub.yml.j2') }}"
+  when:
+    - hub_metrics_enabled|bool
+    - openshift_cluster|bool

--- a/roles/tackle/templates/networkpolicy.yml.j2
+++ b/roles/tackle/templates/networkpolicy.yml.j2
@@ -41,3 +41,18 @@ spec:
   - ports:
     - port: 8080
     - port: 8443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ app_name }}-metrics
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      role: {{ hub_service_name }}
+    ingress:
+    - ports:
+      - port: {{ hub_metrics_port }}

--- a/roles/tackle/templates/servicemonitor-hub.yml.j2
+++ b/roles/tackle/templates/servicemonitor-hub.yml.j2
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ hub_service_name }}
+    app.kubernetes.io/component: {{ hub_component_name }}
+    app.kubernetes.io/part-of: {{ app_name }}
+  name: {{ hub_service_name }}
+  namespace: {{ app_namespace }}
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ hub_service_name }}
+      app.kubernetes.io/component: {{ hub_component_name }}
+      app.kubernetes.io/part-of: {{ app_name }}

--- a/tools/templates/clusterserviceversion.yaml.j2
+++ b/tools/templates/clusterserviceversion.yaml.j2
@@ -228,7 +228,12 @@ spec:
           - servicemonitors
           verbs:
           - get
+          - list
+          - watch
           - create
+          - update
+          - patch
+          - delete
         - apiGroups:
           - apps.openshift.io
           resources:


### PR DESCRIPTION
* Adds a ServiceMonitor to allow the in-cluster monitoring to scrape Hub metrics (requires an OpenShift cluster)
* Adds a NetworkPolicy to expose the Hub's metrics port.
* Adds RBAC roles to allow the operator to manage ServiceMonitors

I'm not sure if there's a better way to test if the monitoring operator is available, or if there's a way to more tightly restrict the network policy.

I'll need to backport this to release-0.2 once it is merged.

Related to https://issues.redhat.com/projects/MTA/issues/MTA-402