### PR TITLE
:seedling:  Disable maven search in github workflows

### DIFF
--- a/.github/actions/install-konveyor/action.yml
+++ b/.github/actions/install-konveyor/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "JSON encoded Tackle Custom Resource (CR) string"
     required: false
     default: ""
+  disable_maven_search:
+    description: "Disable maven central search"
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -40,6 +44,7 @@ runs:
       OPERATOR_BUNDLE_IMAGE: ${{ inputs.bundle_image }}
       NAMESPACE: ${{ inputs.namespace }}
       TACKLE_CR: ${{ inputs.tackle_cr }}
+      DISABLE_MAVEN_SEARCH: ${{ inputs.disable_maven_search }}
     run: make install-konveyor
     working-directory: ${{ github.action_path }}/../../..
     shell: bash

--- a/.github/actions/install-tackle/action.yml
+++ b/.github/actions/install-tackle/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Enable tackle with auth"
     required: false
     default: "false"
+  disable_maven_search:
+    description: "Disable maven central search"
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -64,6 +68,7 @@ runs:
       export IMAGE_PULL_POLICY="${{ inputs.image-pull-policy }}"
       export ANALYZER_CONTAINER_REQUESTS_MEMORY="${{ inputs.analyzer-container-memory }}"
       export ANALYZER_CONTAINER_REQUESTS_CPU="${{ inputs.analyzer-container-cpu }}"
+      export DISABLE_MAVEN_SEARCH=${{ inputs.disable_maven_search }}
       if [[ "true" == "${{ inputs.enable_auth }}" ]]; then
         export FEATURE_AUTH_REQUIRED=true
       fi

--- a/hack/install-konveyor.sh
+++ b/hack/install-konveyor.sh
@@ -10,6 +10,7 @@ OPERATOR_BUNDLE_IMAGE="${OPERATOR_BUNDLE_IMAGE:-quay.io/konveyor/tackle2-operato
 TACKLE_CR="${TACKLE_CR:-}"
 TIMEOUT="${TIMEOUT:-15m}"
 OLM_VERSION="${OLM_VERSION:-0.28.0}"
+DISABLE_MAVEN_SEARCH="${DISABLE_MAVEN_SEARCH:-false}"
 
 if ! command -v kubectl >/dev/null 2>&1; then
   echo "Please install kubectl. See https://kubernetes.io/docs/tasks/tools/"
@@ -91,6 +92,7 @@ metadata:
   name: tackle
 spec:
   feature_auth_required: false
+  disable_maven_search: ${DISABLE_MAVEN_SEARCH}
 EOF
   fi
 

--- a/hack/install-tackle.sh
+++ b/hack/install-tackle.sh
@@ -30,6 +30,7 @@ ANALYZER_CONTAINER_REQUESTS_CPU="${ANALYZER_CONTAINER_REQUESTS_CPU:-0}"
 FEATURE_AUTH_REQUIRED="${FEATURE_AUTH_REQUIRED:-false}"
 TIMEOUT="${TIMEOUT:-15m}"
 OLM_VERSION="${OLM_VERSION:-0.28.0}"
+DISABLE_MAVEN_SEARCH="${DISABLE_MAVEN_SEARCH:-false}"
 
 if ! command -v kubectl >/dev/null 2>&1; then
   kubectl_bin="${__bin_dir}/kubectl"
@@ -125,6 +126,7 @@ spec:
   image_pull_policy: ${IMAGE_PULL_POLICY}
   analyzer_container_requests_memory: ${ANALYZER_CONTAINER_REQUESTS_MEMORY}
   analyzer_container_requests_cpu: ${ANALYZER_CONTAINER_REQUESTS_CPU}
+  disable_maven_search: ${DISABLE_MAVEN_SEARCH}
 EOF
 # Wait for reconcile to finish
 kubectl wait \


### PR DESCRIPTION
Adding option `disable_maven_search` tackle CR setup in hack install scripts (with default false) and adding it to re-usable github actions used on upstream CI with default `true`.

For custom/directly executed install scripts, nothing will be changed by default, but on upstream CI github actions installing konveyor (or older tackle) will have disable_maven_search set to true.

Fixes: https://github.com/konveyor/operator/issues/469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to disable Maven Central search during Konveyor/Tackle installation.
  - Configurable via CI workflow inputs or environment variables, with sensible defaults.
  - Setting is propagated to the generated install configuration for consistent behavior across workflows and scripts.
  - Improves support for offline or restricted environments without changing other install steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->