### PR TITLE
:sparkles: Update create-release.yml to remove duplicate kantra repo

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -145,8 +145,6 @@ jobs:
             image: konveyor/kantra
           - repo: konveyor/tackle2-addon-discovery
             image: konveyor/tackle2-addon-discovery
-          - repo: konveyor/kantra
-            image: konveyor/kantra
           - repo: konveyor/kai
             image: konveyor/kai-solution-server
       fail-fast: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined the release pipeline by removing a duplicate project entry in the release workflow.
  - Reduces redundant runs and slightly speeds up release processing.
  - No changes to app functionality; end users unaffected.
  - Improves CI reliability and clarity for maintainers.
  - Prevents duplicate artifacts during releases.
  - Faster feedback during release runs.
  - No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->