### PR TITLE
:ghost: Set the example to use the key name that will work

### DIFF
--- a/roles/tackle/tasks/kai.yml
+++ b/roles/tackle/tasks/kai.yml
@@ -12,10 +12,10 @@
   when: (kai_api_key_secret_status.resources|length) == 0
   debug:
     msg: >
-         The Kai Solution Server will be able to serve advanced insights until the credential secret exists.
+         The Kai Solution Server will not be able to serve advanced insights until the credential secret exists.
          kubectl create secret -n {{ app_namespace }} generic {{ kai_api_key_secret_name }} --from-literal=<your service's environment variable>=<your API key>
          for example
-         kubectl create secret generic kai-api-key-secret --from-literal=OPENAI_API_KEY=sk-thisisafakekey
+         kubectl create secret -n {{ app_namespace }} generic {{ kai_api_key_secret_name }} --from-literal=OPENAI_API_KEY=sk-thisisafakekey
 
 - when: (kai_api_key_secret_status.resources|length) > 0
   block:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Clarified debug messaging: now explicitly states the Kai Solution Server cannot serve advanced insights until the API key secret exists. Updated the sample secret-creation command to use a namespace-scoped, parameterized secret name (matching deployment variables). No functional or control-flow changes; only message and example text were improved for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->