### PR TITLE
:bug: fix deployment env var handling when switching providers

### DIFF
--- a/roles/tackle/tasks/kai.yml
+++ b/roles/tackle/tasks/kai.yml
@@ -72,6 +72,7 @@
       k8s:
         state: present
         template: kai/kai-api-deployment.yaml.j2
+        merge_type: merge
 
     - name: Create KAI API Service
       k8s:


### PR DESCRIPTION
If you start out using one provider, lets say openai, the deployment will be created with the environment:
```
        - name: OPENAI_API_KEY
          valueFrom:
            secretKeyRef:
              key: OPENAI_API_KEY
              name: kai-api-keys
```

If you then switch to another lets say bedrock and change the secret you'll end up with
```
    - name: AWS_BEARER_TOKEN_BEDROCK
      valueFrom:
        secretKeyRef:
          key: AWS_BEARER_TOKEN_BEDROCK
          name: kai-api-keys
```

But with the default strategic-merge option the deployments openai env var is not cleaned up. It still expects the OPENAI_API_KEY to exist in the secret, even if you're no longer using  it.

Switching to the merge merge_type will ensure that the deployment stays in sync with the keys in the secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kai API deployment behavior to merge updates with existing Kubernetes resources, improving compatibility with cluster-managed fields and reducing the risk of disruptive changes during updates.
  * Service creation remains unchanged.
  * Users should experience smoother, more reliable rollouts with fewer interruptions during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->