### PR TITLE
:seedling: Add stale issue marking workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,48 @@
+name: Mark Stale Issues and PRs
+
+on:
+  schedule:
+    # Runs daily at 1:00 AM UTC
+    - cron: '0 1 * * *'
+  workflow_dispatch: # Allows manual trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Mark as stale after 60 days of inactivity
+          days-before-stale: 60
+
+          # Never auto-close (set to -1 to disable)
+          days-before-close: -1
+
+          # Stale issue configuration
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had any activity for 60 days.
+            It will remain open for visibility and reporting purposes.
+            Please comment if this issue is still relevant.
+          stale-issue-label: 'stale'
+
+          # Stale PR configuration
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had any activity for 60 days.
+            It will remain open for visibility and reporting purposes.
+            Please comment if this PR is still relevant.
+          stale-pr-label: 'stale'
+
+          # Remove stale label when issues/PRs receive new comments or updates
+          remove-stale-when-updated: true
+
+          # Exempt items with these labels from being marked stale
+          exempt-issue-labels: 'security,critical,pinned,blocked,in-progress,under-review,enhancement,tech-debt'
+          exempt-pr-labels: 'security,critical,pinned,blocked,in-progress,under-review,enhancement,tech-debt'
+
+          # Exempt items with assignees
+          exempt-all-issue-assignees: true
+          exempt-all-pr-assignees: true


### PR DESCRIPTION
This PR adds an automated workflow to mark stale issues and pull requests.

**Configuration:**
- Marks items as stale after 60 days of inactivity
- Does not auto-close items (only marks them)
- Exempts items with labels: security, critical, pinned, blocked, in-progress, under-review, enhancement, tech-debt
- Exempts items with assignees
- Automatically removes stale label when items are updated

The workflow runs daily at 1:00 AM UTC and can also be triggered manually.