### PR TITLE
:ghost: Change the default pull policy to IfNotPresent

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -19,7 +19,7 @@ disable_maven_search: false
 
 # Environment
 openshift_cluster: false
-image_pull_policy: "Always"
+image_pull_policy: "IfNotPresent"
 http_proxy: "{{ lookup('env', 'HTTP_PROXY') }}"
 https_proxy: "{{ lookup('env', 'HTTPS_PROXY') }}"
 no_proxy: "{{ lookup('env', 'NO_PROXY') }}"


### PR DESCRIPTION
In most cases IfNotPresent probably makes more sense. It is also considered best practice in OpenShift if I am not mistaken (probably due to the use of SHAs). If someone is working on an install using tags and wants to pull updates to the tag when pods are restarted etc. this can always be overridden in the tackle CR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed container image pull behavior to use "IfNotPresent", so images are only fetched when not already cached locally—reducing unnecessary downloads and improving deployment efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->