### PR TITLE
:bug: fixing issue with new maven index not being available

### DIFF
--- a/roles/tackle/templates/customresource-extension.yml.j2
+++ b/roles/tackle/templates/customresource-extension.yml.j2
@@ -47,6 +47,7 @@ spec:
       initConfig:
       - providerSpecificConfig:
           bundles: /jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar
+          mavenIndexPath: /usr/local/etc/maven-index.txt
           depOpenSourceLabelsFile: /usr/local/etc/maven.default.index
           lspServerPath: /jdtls/bin/jdtls
           disableMavenSearch: {{ disable_maven_search }}


### PR DESCRIPTION
The new cache file needs to be set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Maven index path configuration support to enhance dependency resolution capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->