### PR TITLE
:ghost: control hub logging levels.

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -62,6 +62,12 @@ hub_url: "{{ hub_proto }}://{{ hub_service_name }}.{{ app_namespace }}.svc:{{ hu
 hub_log_level: 3
 hub_metrics_enabled: true
 hub_metrics_port: "2112"
+# Log Level (0-n)
+# hub_log_level_master: 0
+# hub_log_level_migration: 0
+# hub_log_level_web: 0
+# hub_log_level_reaper: 0
+# hub_log_level_task: 0
 
 pathfinder_delete_db_volume: false
 pathfinder_database_name: "pathfinder"

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -98,6 +98,26 @@ spec:
               value: "{{ hub_metrics_enabled }}"
             - name: METRICS_PORT
               value: "{{ hub_metrics_port }}"
+            {% if hub_log_level_master is defined %}
+            - name: LOG_MASTER
+              value: "{{ hub_log_level_master }}"
+            {% endif %}
+            {% if hub_log_level_migration is defined %}
+            - name: LOG_MIGRATION
+              value: "{{ hub_log_level_migration }}"
+            {% endif %}
+            {% if hub_log_level_web is defined %}
+            - name: LOG_WEB
+              value: "{{ hub_log_level_web }}"
+            {% endif %}
+            {% if hub_log_level_reaper is defined %}
+            - name: LOG_REAPER
+              value: "{{ hub_log_level_reaper }}"
+            {% endif %}
+            {% if hub_log_level_task is defined %}
+            - name: LOG_TASK
+              value: "{{ hub_log_level_task }}"
+            {% endif %}
 {% if feature_auth_required|bool and feature_auth_type == "keycloak" %}
             - name: AUTH_REQUIRED
               value: "true"


### PR DESCRIPTION
Support adjusting the log levels for either the entire hub or individual components.
Envar set inside condition because I don't want the default to be controlled on the CR but rather inside the hub.

The logging levels are new in hub 0.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-component logging levels for hub deployment, enabling independent control of logging for master, migration, web, reaper, and task components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->