### PR TITLE
:bug: Add minItems for organizations in platform/cloudfoundry/filter schema

### DIFF
--- a/roles/tackle/templates/customresource-schema.yml.j2
+++ b/roles/tackle/templates/customresource-schema.yml.j2
@@ -95,6 +95,7 @@ spec:
             items:
               type: string
               minLength: 1
+            minItems: 1
           spaces:
             description: Space names.
             type: array


### PR DESCRIPTION
See: https://github.com/konveyor/tackle2-ui/issues/2726

For live discovery, at least one organization name is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data validation to enforce minimum array requirements for improved system reliability and robustness. Array fields and organizations now require at least one item minimum, preventing incomplete configurations and improving overall data consistency. These updates ensure more reliable and robust system behavior when managing resources and organizational structures throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->