### PR TITLE
:bug: Fix condition guarding for kai tasks, handling of trusted_ca_bundle

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -277,6 +277,7 @@ kai_log_level: info
 kai_enable_demo_mode: "false"
 kai_enable_trace: "true"
 
+
 kai_llm_model: null
 kai_llm_provider: null
 kai_llm_baseurl: null
@@ -297,7 +298,9 @@ kai_llm_params:
     base_url: "{{ kai_llm_baseurl }}"
     kwargs: "{{ kai_llm_model_specific_kwargs }}"
 
+
 # LLM params when using the proxy - points to the local llm-proxy service
+kai_llm_proxy_provider_id: "{{ kai_llm_provider }}"
 kai_llm_params_proxy:
   model: "{{ kai_llm_proxy_provider_id }}/{{ kai_llm_model }}"
   model_provider: "openai_api"
@@ -338,7 +341,6 @@ kai_llm_proxy_provider_type_map:
 
 # Computed provider type - uses map or falls back to remote::<provider_name>
 kai_llm_proxy_provider_type: "{{ kai_llm_proxy_provider_type_map[kai_llm_provider] | default('remote::' + kai_llm_provider) if kai_llm_provider else 'remote::openai' }}"
-kai_llm_proxy_provider_id: "{{ kai_llm_provider | default('openai') }}"
 
 # API key environment variable name - map provider to expected env var
 kai_llm_proxy_api_key_env_map:

--- a/roles/tackle/tasks/kai.yml
+++ b/roles/tackle/tasks/kai.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Verify API key secret is defined
+- name: Get API key secret
   k8s_info:
     api_version: v1
     kind: Secret
@@ -8,17 +8,9 @@
     namespace: "{{ app_namespace }}"
   register: kai_api_key_secret_status
 
-- name: Verify kai-api-key-secret has been created
-  when: (kai_api_key_secret_status.resources|length) == 0
-  debug:
-    msg: >
-         The Kai Solution Server will not be able to serve advanced insights until the credential secret exists.
-         kubectl create secret -n {{ app_namespace }} generic {{ kai_api_key_secret_name }} --from-literal=<your service's environment variable>=<your API key>
-         for example
-         kubectl create secret -n {{ app_namespace }} generic {{ kai_api_key_secret_name }} --from-literal=OPENAI_API_KEY=sk-thisisafakekey
-
-- when: (kai_api_key_secret_status.resources|length) > 0
+- when: kai_llm_proxy_enabled|bool or kai_solution_server_enabled|bool
   block:
+
     - name: Check if DB secret is defined
       k8s_info:
         api_version: v1
@@ -92,16 +84,19 @@
             state: present
             template: kai/llm-proxy-client-configmap.yaml.j2
 
-    - name: Create Kai API deployment
-      k8s:
-        state: present
-        template: kai/kai-api-deployment.yaml.j2
-        merge_type: merge
+    - name: Deploy Solution server
+      when: kai_solution_server_enabled | bool
+      block:
+        - name: Create Kai API deployment
+          k8s:
+            state: present
+            template: kai/kai-api-deployment.yaml.j2
+            merge_type: merge
 
-    - name: Create KAI API Service
-      k8s:
-        state: present
-        template: kai/kai-api-service.yaml.j2
+        - name: Create KAI API Service
+          k8s:
+            state: present
+            template: kai/kai-api-service.yaml.j2
 
 - name: Update Kai component status conditions
   when: ansible_operator_meta is defined

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -916,5 +916,4 @@
     msg: "kai_solution_server_enabled = {{ kai_solution_server_enabled }}, will run kai tasks = {{ kai_solution_server_enabled | bool }}"
 
 - name: Run kai tasks
-  when: kai_solution_server_enabled | bool
   import_tasks: kai.yml

--- a/roles/tackle/templates/kai/llm-proxy-deployment.yaml.j2
+++ b/roles/tackle/templates/kai/llm-proxy-deployment.yaml.j2
@@ -59,7 +59,7 @@ spec:
               value: /app/run.yaml
             - name: LLAMA_STACK_CONFIG_DIR
               value: /tmp/.llama
-{% if feature_auth_required and keycloak_sso_proto == 'https' %}
+{% if trusted_ca_enabled | default(false) | bool %}
             # For self-signed certificates
             - name: SSL_CERT_FILE
               value: /etc/pki/ca-trust/source/anchors/ca.crt
@@ -86,7 +86,7 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
-{% if feature_auth_required and keycloak_sso_proto == 'https' %}
+{% if trusted_ca_enabled | default(false) | bool %}
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/source/anchors
               readOnly: true
@@ -104,7 +104,7 @@ spec:
             name: llm-proxy
         - name: tmp
           emptyDir: {}
-{% if feature_auth_required and keycloak_sso_proto == 'https' %}
+{% if trusted_ca_enabled | default(false) | bool %}
         - name: trusted-ca
           configMap:
             name: trusted-ca


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable LLM settings (model, provider, base URL, temperature, token limits, retries, model-specific kwargs).
  * Added configurable LLM proxy parameters and proxy provider mapping.

* **Changes**
  * Deployment and task gating simplified: solution server and LLM proxy tasks now follow clearer enablement flags and conditional flow.
  * One LLM task group now runs unconditionally.
  * Trusted CA handling consolidated under a single trusted-ca flag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->