### PR TITLE
:bug: use correct URL in issuer for llm-proxy

### DIFF
--- a/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
+++ b/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
@@ -110,8 +110,10 @@ data:
         provider_config:
           type: "oauth2_token"
           jwks:
-            uri: "http://{{ keycloak_sso_service_name }}:{{ keycloak_sso_port }}/auth/realms/{{ keycloak_sso_realm }}/protocol/openid-connect/certs"
-          issuer: "http://{{ keycloak_sso_service_name }}.{{ app_namespace }}.svc:{{ keycloak_sso_port }}/auth/realms/{{ keycloak_sso_realm }}"
+            # Use the same protocol and base URL that the hub uses for Keycloak
+            uri: "{{ keycloak_sso_url }}/auth/realms/{{ keycloak_sso_realm }}/protocol/openid-connect/certs"
+          # The issuer must match exactly what's in the JWT token from hub auth
+          issuer: "{{ keycloak_sso_url }}/auth/realms/{{ keycloak_sso_realm }}"
           audience: "{{ keycloak_api_audience }}"
 {% endif %}
     telemetry:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated authentication service configuration to use external URLs for certificate verification and issuer validation.
  * Added clarifying comments to authentication settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->