### PR TITLE
:bug: When connecting to internal keycloak via https, skip tls_verify

### DIFF
--- a/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
+++ b/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
@@ -109,6 +109,8 @@ data:
       auth:
         provider_config:
           type: "oauth2_token"
+          # Skip TLS verification for self-signed certificates (same as hub does)
+          verify_tls: false
           jwks:
             # Use the same protocol and base URL that the hub uses for Keycloak
             uri: "{{ keycloak_sso_url }}/auth/realms/{{ keycloak_sso_realm }}/protocol/openid-connect/certs"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configuration option to disable TLS verification for authentication providers, enabling secure connections to services using self-signed certificates. This enhancement improves deployment flexibility and maintains consistency with existing platform capabilities, allowing teams to work effectively with diverse certificate configurations in various environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->