### PR TITLE
:bug: MTA-6270 - Change mount path for UI TLS secret

### DIFF
--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -165,7 +165,7 @@ spec:
           volumeMounts:
 {% if ui_tls_enabled|bool %}
             - name: {{ ui_tls_secret_name }}
-              mountPath: /var/run/secrets/{{ ui_tls_secret_name }}/tls.crt
+              mountPath: /var/run/secrets/{{ ui_tls_secret_name }}
 {% endif %}
 {% if trusted_ca_enabled is defined and trusted_ca_enabled|bool %}
             - name: trusted-ca


### PR DESCRIPTION
Update mount path for UI TLS secret in deployment template to fix https://issues.redhat.com/browse/MTA-6270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TLS certificate mounting configuration in the deployment template to ensure the UI component properly accesses certificate files for secure communication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->