### PR TITLE
:bug: Set force-ssl-redirect if feature_auth_required

### DIFF
--- a/roles/tackle/templates/ingress-ui.yml.j2
+++ b/roles/tackle/templates/ingress-ui.yml.j2
@@ -5,6 +5,9 @@ metadata:
   annotations:
 {% if ui_ingress_class_name == 'nginx' %}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ ui_ingress_proxy_body_size }}
+{% if feature_auth_required|bool and feature_auth_type == "keycloak" %}
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+{% endif %}
 {% elif ui_ingress_class_name == 'alb' %}
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/scheme: internet-facing


### PR DESCRIPTION
Fixes #453 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security issue where HTTP traffic was not being redirected to HTTPS when using Keycloak authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->