### PR TITLE
:bug: Update inaccurate RHBK task names

### DIFF
--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -537,11 +537,11 @@
       retries: 30
       delay: 5
 
-    - name: "Set number of RHBK instances to 0 to prepare secret resources"
+    - name: "Set number of RHBK instances to 1"
       set_fact:
         rhbk_instances: 1
 
-    - name: "Create RHBK Keycloak CR"
+    - name: "Update RHBK Keycloak CR"
       k8s:
         state: present
         definition: "{{ lookup('template', 'customresource-rhbk-keycloak.yml.j2') }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Set RHBK deployment replica count to 1 during secret resource preparation (previously 0), ensuring resources are prepared without conditional readiness constraints.
  * Switched RHBK Keycloak operation from "Create" to "Update" to make the configuration apply idempotently and reflect ongoing updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->