### PR TITLE
:bug: Disable hub chown init container by default and always exit 0

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -16,6 +16,7 @@ feature_discovery: true
 
 # Options.
 # task_pod_quota: 50
+enable_chown_init_container: false
 disable_maven_search: false
 
 # Environment

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -236,13 +236,12 @@ spec:
             - name: {{ hub_tls_secret_name }}
               mountPath: /var/run/secrets/{{ hub_tls_secret_name }}/tls.crt
 {% endif %}
+{% if enable_chown_init_container|bool %}
       initContainers:
         - command:
-            - chown
-            - -R
-            - {{ hub_uid }}:root
-            - {{ hub_database_volume_path }}
-            - {{ hub_bucket_volume_path }}
+            - bash
+            - -c
+            - 'chown -R {{ hub_uid }}:root {{ hub_database_volume_path }} {{ hub_bucket_volume_path }} ||:'
           image: "{{ hub_image_fqin }}"
           imagePullPolicy: "{{ image_pull_policy }}"
           name: update-perms
@@ -260,6 +259,7 @@ spec:
               name: {{ hub_database_volume_name }}
             - mountPath: {{ hub_bucket_volume_path }}
               name: {{ hub_bucket_volume_name }}
+{% endif %}
       volumes:
 {% if rwx_supported|bool %}
         - name: {{ cache_data_volume_name }}


### PR DESCRIPTION
This init container was originally used to fix permissions when upgrading from an older version that ran as root and probably isn't need most of the time anymore. Allowing it to be enabled still allows for the situation to be corrected if someone is upgrading from a very old version, but otherwise should no longer incur an ohterwise needless  wait when the hub is starts.

Also added `||:` to ensure the container exits gracefully even if it can't change permissions on read only subdirectories, which may be outside the users control to adjust. This prevents the init container from crashing and preventing the hub from starting. NetApp .snapshot directory is an example of this. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to optionally enable automated file ownership management for database and bucket volumes during container initialization. Disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->