### PR TITLE
:bug: Fix llm-proxy JWT issuer mismatch on MTA profile

### DIFF
--- a/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
+++ b/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
@@ -112,9 +112,15 @@ data:
           verify_tls: false
           jwks:
             # Use the same protocol and base URL that the hub uses for Keycloak
+{% if app_profile == 'mta' %}
+            uri: "{{ rhbk_url }}/auth/realms/{{ keycloak_sso_realm }}/protocol/openid-connect/certs"
+          # The issuer must match exactly what's in the JWT token from hub auth
+          issuer: "{{ rhbk_url }}/auth/realms/{{ keycloak_sso_realm }}"
+{% else %}
             uri: "{{ keycloak_sso_url }}/auth/realms/{{ keycloak_sso_realm }}/protocol/openid-connect/certs"
           # The issuer must match exactly what's in the JWT token from hub auth
           issuer: "{{ keycloak_sso_url }}/auth/realms/{{ keycloak_sso_realm }}"
+{% endif %}
           audience: "{{ keycloak_api_audience }}"
 {% endif %}
     telemetry:

--- a/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
+++ b/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
@@ -104,7 +104,7 @@ data:
       tool_groups: []
     server:
       port: 8321
-{% if feature_auth_required %}
+{% if feature_auth_required|bool %}
       auth:
         provider_config:
           type: "oauth2_token"


### PR DESCRIPTION
The llm-proxy configmap template always used keycloak_sso_url for the JWKS URI and issuer, which resolves to mta-keycloak-rhbk on the MTA profile. However, the actual RHBK service is mta-rhbk-service, and the hub already correctly uses rhbk_url for MTA. This caused the llm-proxy to reject all JWT tokens with "Invalid JWT token" because the issuer in the token didn't match what the proxy expected.

Add the same app_profile == 'mta' conditional used by the hub and UI templates so the llm-proxy uses rhbk_url on MTA and keycloak_sso_url on konveyor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved OAuth2/OpenID Connect configuration: the system now correctly interprets the authentication-required flag and selects the appropriate JWKS URI and issuer depending on the deployment profile (including a new branch for the "mta" profile). This improves authentication behavior across different environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->