### PR TITLE
Revert ":bug: Fix cannot read database on OCP."

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -16,7 +16,7 @@ feature_discovery: true
 
 # Options.
 # task_pod_quota: 50
-enable_chown_init_container: true
+enable_chown_init_container: false
 disable_maven_search: false
 
 # Environment


### PR DESCRIPTION
Reverts konveyor/operator#548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Initialization container is now disabled by default in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->