### PR TITLE
:bug: Fix llm-proxy Gemini/Google provider mapping

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -319,7 +319,7 @@ kai_llm_proxy_model_prefix_map:
   google: "models/"
   gemini: "models/"
 kai_llm_proxy_model_prefix: "{{ kai_llm_proxy_model_prefix_map[kai_llm_provider] | default('') }}"
-kai_llm_proxy_model_id: "{{ kai_llm_proxy_model_prefix + kai_llm_model if kai_llm_model else kai_llm_model }}"
+kai_llm_proxy_model_id: "{{ kai_llm_model if (not kai_llm_model) or kai_llm_model.startswith(kai_llm_proxy_model_prefix) else kai_llm_proxy_model_prefix + kai_llm_model }}"
 kai_llm_params_proxy:
   model: "{{ kai_llm_proxy_provider_id }}/{{ kai_llm_proxy_model_id }}"
   model_provider: "openai_api"

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -314,8 +314,14 @@ kai_llm_params:
 
 # LLM params when using the proxy - points to the local llm-proxy service
 kai_llm_proxy_provider_id: "{{ kai_llm_provider }}"
+# Some providers require a prefix on model IDs (e.g. Gemini uses 'models/')
+kai_llm_proxy_model_prefix_map:
+  google: "models/"
+  gemini: "models/"
+kai_llm_proxy_model_prefix: "{{ kai_llm_proxy_model_prefix_map[kai_llm_provider] | default('') }}"
+kai_llm_proxy_model_id: "{{ kai_llm_proxy_model_prefix + kai_llm_model if kai_llm_model else kai_llm_model }}"
 kai_llm_params_proxy:
-  model: "{{ kai_llm_proxy_provider_id }}/{{ kai_llm_model }}"
+  model: "{{ kai_llm_proxy_provider_id }}/{{ kai_llm_proxy_model_id }}"
   model_provider: "openai_api"
   configurable_fields:
     temperature: "{{ kai_llm_temperature }}"
@@ -347,8 +353,8 @@ kai_llm_proxy_provider_type_map:
   openai_api: "remote::openai"
   azure: "remote::azure-openai"
   azure_openai: "remote::azure-openai"
-  google: "remote::google"
-  gemini: "remote::google"
+  google: "remote::gemini"
+  gemini: "remote::gemini"
   bedrock: "remote::bedrock"
   anthropic: "remote::anthropic"
 

--- a/roles/tackle/templates/kai/llm-proxy-client-configmap.yaml.j2
+++ b/roles/tackle/templates/kai/llm-proxy-client-configmap.yaml.j2
@@ -12,5 +12,5 @@ metadata:
 data:
   config.json: |
     {
-      "model": "{{ kai_llm_proxy_provider_id }}/{{ kai_llm_model }}"
+      "model": "{{ kai_llm_proxy_provider_id }}/{{ kai_llm_proxy_model_id }}"
     }

--- a/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
+++ b/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
@@ -34,7 +34,7 @@ data:
           base_url: ${env.AZURE_OPENAI_ENDPOINT}
 {% endif %}
           api_version: ${env.AZURE_OPENAI_API_VERSION:2024-02-15-preview}
-{% elif kai_llm_proxy_provider_type == 'remote::google' %}
+{% elif kai_llm_proxy_provider_type == 'remote::gemini' %}
           api_key: ${env.GOOGLE_API_KEY}
 {% if kai_llm_baseurl %}
           base_url: {{ kai_llm_baseurl }}
@@ -92,7 +92,7 @@ data:
       - model_id: proxied-model
         provider_id: {{ kai_llm_proxy_provider_id }}
         model_type: llm
-        provider_model_id: {{ kai_llm_model }}
+        provider_model_id: {{ kai_llm_proxy_model_id }}
 {% else %}
       models: []
 {% endif %}

--- a/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
+++ b/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
@@ -87,7 +87,7 @@ data:
           table_name: llm_proxy_conversations
           backend: sql_default
     registered_resources:
-{% if kai_llm_model %}
+{% if kai_llm_proxy_model_id %}
       models:
       - model_id: proxied-model
         provider_id: {{ kai_llm_proxy_provider_id }}


### PR DESCRIPTION
## Summary

- Fix `kai_llm_proxy_provider_type_map` for `gemini`/`google`: the llama-stack image registers the provider as `remote::gemini`, not `remote::google`, which caused llm-proxy to crash on startup with `ValueError: Provider 'remote::google' is not available for API 'Api.inference'`
- Fix model ID mapping: Google's OpenAI-compatible API returns model IDs with a `models/` prefix (e.g. `models/gemini-2.5-flash`), which llama-stack validates during model registration. Added a `kai_llm_proxy_model_prefix_map` to handle this per-provider, following the same pattern as the existing `provider_type_map` and `api_key_env_map`
- Updated the configmap and client-configmap templates to use the new `kai_llm_proxy_model_id` variable, keeping `kai_llm_model` clean for kai-api

## Workaround for current users (without this fix)

Users on the current operator can work around both issues by setting these overrides directly in the Tackle CR (CR spec values are passed as `-e` to Ansible and take highest precedence):

```yaml
spec:
  kai_llm_proxy_enabled: true
  kai_llm_provider: gemini
  kai_llm_model: models/gemini-2.5-flash
  kai_llm_proxy_provider_type: "remote::gemini"
```

**Limitation:** the `models/` prefix in `kai_llm_model` leaks into kai-api's model config, so `kai_solution_server_enabled` must be `false` when using this workaround. This PR removes that limitation by computing the prefix separately for the proxy.

## Test plan

- [x] Deployed on kind cluster via Helm with `kai_llm_provider: gemini`, `kai_llm_model: gemini-2.5-flash`
- [x] Verified llm-proxy starts successfully with `remote::gemini` provider
- [x] Verified chat completions proxied to Gemini API return valid responses
- [x] Verified invalid JWT tokens are rejected (HTTP 401)
- [x] Verified health endpoint returns 200
- [x] Verify no regression on OpenAI/Anthropic provider paths (template conditionals unchanged for those)

closes https://github.com/konveyor/editor-extensions/issues/1143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Improved LLM proxy model identifier handling to support provider-specific model prefixes and ensure the proxy targets the correct model string.
  * Standardized provider type mapping to use a single provider type for related backends.

* **Bug Fixes**
  * Fixed incorrect composition of proxied model IDs so registrations and config outputs reference the intended model identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->