### PR TITLE
:bug: register LLM proxy model with provider-prefixed model_id

### DIFF
--- a/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
+++ b/roles/tackle/templates/kai/llm-proxy-configmap.yaml.j2
@@ -89,7 +89,7 @@ data:
     registered_resources:
 {% if kai_llm_proxy_model_id %}
       models:
-      - model_id: proxied-model
+      - model_id: {{ kai_llm_proxy_provider_id }}/{{ kai_llm_proxy_model_id }}
         provider_id: {{ kai_llm_proxy_provider_id }}
         model_type: llm
         provider_model_id: {{ kai_llm_proxy_model_id }}


### PR DESCRIPTION
## Problem

The LLM proxy (llama-stack) registers its model with `model_id: proxied-model`, but the client configmap (`llm-proxy-client-configmap.yaml.j2`) advertises the model as `openai/gpt-4o`, and downstream consumers (kai-api, editor-extensions, CI tests) send requests using that name.

llama-stack routes requests strictly by `model_id`. When clients send `"model": "gpt-4o"` or `"model": "openai/gpt-4o"`, llama-stack returns:

```
ModelNotFoundError: Model 'gpt-4o' not found.
```

## Fix

Change the registered `model_id` from the hardcoded `proxied-model` to `{{ kai_llm_proxy_provider_id }}/{{ kai_llm_proxy_model_id }}`.

For the default OpenAI provider with gpt-4o, this registers the model as `openai/gpt-4o` — matching what the client configmap advertises and what downstream consumers send.

## Impact

- Requests with `"model": "openai/gpt-4o"` will now resolve correctly in llama-stack
- The `kai_llm_params_proxy` variable already computes this prefixed name for kai-api, so this aligns the proxy registration with existing downstream expectations
- editor-extensions E2E infrastructure tests will stop getting 404s from the LLM proxy

Fixes #570