### PR TITLE
:bug: fix start-minikube action to pass through memory input

### DIFF
--- a/.github/actions/start-minikube/action.yml
+++ b/.github/actions/start-minikube/action.yml
@@ -36,7 +36,7 @@ runs:
       container-runtime: ${{ inputs.container-runtime }}
       kubernetes-version: ${{ inputs.kubernetes-version }}
       cpus: ${{ inputs.cpus }}
-      memory: 8000
+      memory: ${{ inputs.memory }}
       cni: ${{ inputs.cni }}
   # Don't pass minikube start ${ARGS} as they are handled in setup-minikube
   - name: Start minikube


### PR DESCRIPTION
## Summary

The `start-minikube` action accepts a `memory` input but was ignoring it — the `medyagh/setup-minikube` call hardcoded `memory: 8000`. This meant callers passing `memory: "max"` (like editor-extensions E2E workflows) got exactly 8000MB regardless of available runner memory.

## Problem

With the full Konveyor stack (hub, postgres, kai-api, kai-db, llm-proxy, llemulator, operator, nginx ingress) all sharing a hardcoded 8GB, the system runs under significant memory pressure on GitHub Actions runners. This causes:
- Hub API requests randomly timing out (10-30s+)
- Flaky E2E tests that pass intermittently depending on GC/swap timing
- Profile sync and token exchange requests hanging

## Fix

One-line change: `memory: 8000` → `memory: ${{ inputs.memory }}`

This respects the caller's intent. When `memory` is empty string (default), `medyagh/setup-minikube` uses its own default. When `"max"` is passed, minikube uses all available RAM.

Fixes #575

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to improve flexibility in build environment parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->