### PR TITLE
:bug: Detect proper rhbk statefulset name

### DIFF
--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -59,7 +59,7 @@
       k8s_info:
         api_version: apps/v1
         kind: StatefulSet
-        name: "keycloak"
+        name: "mta-rhbk"
         namespace: "{{ app_namespace }}"
       register: rhbk_statefulset
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Keycloak detection for RHBK StatefulSets, ensuring related service details and status information are identified accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->